### PR TITLE
feat: Query Cancellation support

### DIFF
--- a/.changeset/thick-kids-double.md
+++ b/.changeset/thick-kids-double.md
@@ -1,0 +1,7 @@
+---
+"@openapi-qraft/react": patch
+"@openapi-qraft/cli": patch
+"playground": patch
+---
+
+feature: add support for `cancelQueries` method

--- a/packages/cli/src/lib/ts-factory/getClientFactory.ts
+++ b/packages/cli/src/lib/ts-factory/getClientFactory.ts
@@ -186,4 +186,5 @@ const serviceCallbacks = [
   'useQueries',
   'useSuspenseQueries',
   'invalidateQueries',
+  'cancelQueries',
 ] as const;

--- a/packages/react-client/README.md
+++ b/packages/react-client/README.md
@@ -174,7 +174,7 @@ function App() {
 With the client set up, you can now use the generated Hooks in your React Components to fetch data, execute mutations,
 and more.
 
-### [useQuery 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery)
+### [useQuery(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery)
 
 ```ts
 /**
@@ -193,7 +193,7 @@ const { data, error, isPending } = qraft.entities.getEntities.useQuery({
 });
 ```
 
-### [useMutation 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useMutation)
+### [useMutation(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useMutation)
 
 #### With predefined parameters
 
@@ -253,7 +253,7 @@ mutation.mutate({
 });
 ```
 
-### [useMutationState 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useMutationState)
+### [useMutationState(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useMutationState)
 
 Mutation state is a helper hook that provides the current state of a mutation globally.
 It could be used to track the status of a mutation in any component, which is useful for showing loading spinners or
@@ -281,7 +281,7 @@ useEffect(() => {
 }, [mutate, mutationState?.status]);
 ```
 
-### [useInfiniteQuery 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery)
+### [useInfiniteQuery(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery)
 
 #### _Offset-based_
 
@@ -358,7 +358,7 @@ infiniteQuery.fetchNextPage();
 infiniteQuery.fetchPreviousPage();
 ```
 
-### [useQueries 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useQueries)
+### [useQueries(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useQueries)
 
 ```ts
 /**
@@ -397,7 +397,7 @@ qraft.entities.getEntities.useQueries({
 });
 ```
 
-### [invalidateQueries 🔗](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientinvalidatequeries)
+### [invalidateQueries(...) 🔗](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientinvalidatequeries)
 
 [Queries Invalidation 🔗](https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation) is possible
 using `<operation>.invalidateQueries(..)` method.
@@ -510,9 +510,9 @@ same interface as `invalidateQueries(..)`, but it will cancel the queries instea
 
 Supported Suspense Queries are:
 
-- [useSuspenseQuery 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useSuspenseQuery)
-- [useSuspenseInfiniteQuery 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useSuspenseInfiniteQuery)
-- [useSuspenseQueries 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useSuspenseQueries)
+- [useSuspenseQuery(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useSuspenseQuery)
+- [useSuspenseInfiniteQuery(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useSuspenseInfiniteQuery)
+- [useSuspenseQueries(...) 🔗](https://tanstack.com/query/latest/docs/framework/react/reference/useSuspenseQueries)
 
 ### Documentation in Progress 🚧
 

--- a/packages/react-client/README.md
+++ b/packages/react-client/README.md
@@ -501,6 +501,11 @@ qraft.entities.getEntities.invalidateQueries(
 );
 ```
 
+### [cancelQueries(...) 🔗](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientcancelqueries)
+
+[Query Cancellation](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation) has the
+same interface as `invalidateQueries(..)`, but it will cancel the queries instead of invalidating them.
+
 ### Suspense Queries
 
 Supported Suspense Queries are:

--- a/packages/react-client/src/callbacks/cancelQueries.ts
+++ b/packages/react-client/src/callbacks/cancelQueries.ts
@@ -1,21 +1,21 @@
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 import type { QraftClientOptions } from '../qraftAPIClient.js';
 import type { RequestClientSchema } from '../RequestClient.js';
-import type { ServiceOperationInvalidateQueriesCallback } from '../ServiceOperation.js';
+import { ServiceOperationCancelQueriesCallback } from '../ServiceOperation.js';
 
-export function invalidateQueries<TData>(
+export function cancelQueries<TData>(
   qraftOptions: QraftClientOptions | undefined,
   schema: RequestClientSchema,
   args: Parameters<
-    ServiceOperationInvalidateQueriesCallback<
+    ServiceOperationCancelQueriesCallback<
       RequestClientSchema,
       unknown,
       TData
-    >['invalidateQueries']
+    >['cancelQueries']
   >
 ): Promise<void> {
   return callQueryClientMethodWithQueryFilters(
-    'invalidateQueries',
+    'cancelQueries',
     schema,
     args as never
   ) as never;

--- a/packages/react-client/src/lib/callQueryClientMethodWithQueryFilters.ts
+++ b/packages/react-client/src/lib/callQueryClientMethodWithQueryFilters.ts
@@ -1,0 +1,84 @@
+import type { QueryClient } from '@tanstack/query-core';
+
+import type { RequestClientSchema } from '../RequestClient.js';
+import { composeQueryKey } from './composeQueryKey.js';
+
+/**
+ * Calls a query client method with query filters and options,
+ * and automatically composes the `QueryKey` based on the schema and parameters.
+ */
+export function callQueryClientMethodWithQueryFilters<
+  QFMethod extends QueryFilterMethods,
+>(
+  queryFilterMethod: QFMethod,
+  schema: RequestClientSchema,
+  args: [QueryClient, ...Parameters<(typeof QueryClient.prototype)[QFMethod]>]
+): ReturnType<(typeof QueryClient.prototype)[QFMethod]> {
+  const queryClient = (
+    args.length === 1
+      ? args[0]
+      : args.length === 2
+        ? args[1]
+        : args.length === 3
+          ? args[2]
+          : undefined
+  ) as QueryClient | undefined;
+
+  const filters = args.length === 1 ? undefined : args[0];
+  const options = args.length === 3 ? args[1] : undefined;
+
+  if (!queryClient) throw new Error('queryClient is required');
+  if (!queryClient[queryFilterMethod])
+    throw new Error(
+      `queryClient is invalid, ${queryFilterMethod} method does not exist`
+    );
+
+  if (!filters) {
+    return queryClient[queryFilterMethod](
+      {
+        queryKey: composeQueryKey(schema, undefined),
+      },
+      options as never
+    ) as never;
+  }
+
+  if ('queryKey' in filters) {
+    return queryClient[queryFilterMethod](
+      filters as never,
+      options as never
+    ) as never;
+  }
+
+  if ('parameters' in filters) {
+    const { parameters, ...filtersRest } = filters;
+
+    return queryClient[queryFilterMethod](
+      {
+        ...filtersRest,
+        queryKey: composeQueryKey(schema, parameters),
+      } as never,
+      options as never
+    ) as never;
+  }
+
+  return queryClient[queryFilterMethod](
+    {
+      ...filters,
+      queryKey: composeQueryKey(schema, undefined),
+    } as never,
+    options as never
+  ) as never;
+}
+
+type QueryFiltersMethod<QFMethod extends keyof typeof QueryClient.prototype> =
+  QFMethod;
+
+type QueryFilterMethods =
+  | QueryFiltersMethod<'isFetching'>
+  | QueryFiltersMethod<'getQueriesData'>
+  | QueryFiltersMethod<'setQueriesData'>
+  | QueryFiltersMethod<'removeQueries'>
+  | QueryFiltersMethod<'resetQueries'>
+  | QueryFiltersMethod<'cancelQueries'>
+  | QueryFiltersMethod<'invalidateQueries'>
+  | QueryFiltersMethod<'refetchQueries'>;


### PR DESCRIPTION
Add support for `QueryClient` method `cancelQueries(...)`.

Example: 
```ts
qraft.pet.getPetById.cancelQueries(
  { parameters: { path: { petId } } },
  queryClient
)
```