### PR TITLE
feat(cli): configurable service basename by endpoint

### DIFF
--- a/.changeset/tidy-walls-fix.md
+++ b/.changeset/tidy-walls-fix.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/cli": minor
+---
+
+Added support for `--service-name-base <endpoint[<index>]>` option

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,7 +79,7 @@ the `schema.json` file.
   - Example: `--file-header '/* eslint-disable */'`
 - **`--postfix-services <string>`:** Customize the generated service names with a specific postfix _(optional, default: `Service`)_.
   - Example: `--postfix-services Endpoint` will generate `services/UserEndpoint.ts` instead of `services/UserService.ts`.
-- **`--service-name-base <endpoint | endpoint[<index>] | tags>`:** Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: `/0/1/2`) or `tags` as the base name of the service. _(optional, default: `endpoint[0]`)_.
+- **`--service-name-base <endpoint[<index>] | tags>`:** Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: `/0/1/2`) or `tags` as the base name of the service. _(optional, default: `endpoint[0]`)_.
   - Examples:
     - `--service-name-base endpoint[0]` generates `services/FooService.ts`. from endpoint `/foo/bar/baz`
     - `--service-name-base endpoint[1]` generates `services/BarService.ts`. from endpoint `/foo/bar/baz`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,12 +79,14 @@ the `schema.json` file.
   - Example: `--file-header '/* eslint-disable */'`
 - **`--postfix-services <string>`:** Customize the generated service names with a specific postfix _(optional, default: `Service`)_.
   - Example: `--postfix-services Endpoint` will generate `services/UserEndpoint.ts` instead of `services/UserService.ts`.
-- **`--service-name-base <endpoint | tags>`:** Use OpenAPI Operation `endpoint` or `tags` as the base name of the service _(optional, default: `endpoint`)_.
+- **`--service-name-base <endpoint | endpoint[<index>] | tags>`:** Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: `/0/1/2`) or `tags` as the base name of the service. _(optional, default: `endpoint[0]`)_.
   - Examples:
-    - `--service-name-base endpoint` will generate services based on the OpenAPI Operation endpoint.
+    - `--service-name-base endpoint[0]` generates `services/FooService.ts`. from endpoint `/foo/bar/baz`
+    - `--service-name-base endpoint[1]` generates `services/BarService.ts`. from endpoint `/foo/bar/baz`
+    - `--service-name-base endpoint[2]` generates `services/BarService.ts`. from endpoint `/foo/bar` _(if the endpoint is shorter than the index, the last part is used)_
     - `--service-name-base tags` will generate services based on the OpenAPI Operation tags instead of the endpoint.
-      - If multiple tags are present for the operation, similar services will be created for each tag.
-      - If there are no tags for the operation, the services will be created under the `default` tag.
+      - If multiple tags are present for the operation, similar services will be created for each tag. Operation with `tags: [Foo, Bar]` will generate `services/FooService.ts` and `services/BarService.ts`.
+      - If there are no tags for the operation, the services will be created under the `default` tag. Operation with empty `tags: []` will generate `services/DefaultService.ts`.
 - **`--explicit-import-extensions`:** Include explicit `.js` extensions in all import statements. Ideal for projects
   using ECMAScript modules when TypeScript's _--moduleResolution_ is `node16` or `nodenext` _(optional)_.
 - **`-h, --help`:** Display help for the command (optional).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "rimraf dist/ && tsc --project tsconfig.build.json",
     "dev": "yarn build --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "type": "module",
   "bin": {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -42,9 +42,9 @@ program
     'All import statements will include explicit `.js` extensions. Ideal for projects using ECMAScript modules.'
   )
   .option(
-    '--service-name-base <endpoint | tags>',
-    'Use OpenAPI Operation `endpoint` or `tags` as the base name of the service',
-    'endpoint'
+    '--service-name-base <endpoint[<index>] | tags>',
+    'Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: "/0/1/2") or `tags` as the base name of the service.',
+    'endpoint[0]'
   )
   .action(async (input, args) => {
     const { version: packageVersion, name: packageName } = JSON.parse(

--- a/packages/cli/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
+++ b/packages/cli/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
@@ -240,6 +240,66 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
 exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
 [
   {
+    "fileBaseName": "DefaultService",
+    "name": "default",
+    "operations": [
+      {
+        "deprecated": undefined,
+        "description": "Retrieve a specific approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "get",
+        "name": "getApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Order by",
+            "in": "query",
+            "name": "items_order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "description": "Order by",
+              "items": {
+                "$ref": "#/components/schemas/OrderEnum",
+              },
+              "type": "array",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Get an approval policy by ID",
+      },
+    ],
+    "typeName": "DefaultService",
+    "variableName": "defaultService",
+  },
+  {
     "fileBaseName": "ApprovalPoliciesService",
     "name": "approvalPolicies",
     "operations": [
@@ -908,243 +968,6 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
     ],
     "typeName": "FilesService",
     "variableName": "filesService",
-  },
-]
-`;
-
-exports[`getServices > matches snapshot with custom options 1`] = `
-[
-  {
-    "fileBaseName": "ApprovalPoliciesSrv",
-    "name": "approvalPolicies",
-    "operations": [
-      {
-        "deprecated": undefined,
-        "description": "Retrieve a specific approval policy.",
-        "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
-        },
-        "mediaType": undefined,
-        "method": "get",
-        "name": "getApprovalPoliciesId",
-        "parameters": [
-          {
-            "example": "2023-06-04",
-            "in": "header",
-            "name": "x-monite-version",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string",
-            },
-          },
-          {
-            "in": "path",
-            "name": "approval_policy_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-            },
-          },
-          {
-            "description": "Order by",
-            "in": "query",
-            "name": "items_order",
-            "required": false,
-            "schema": {
-              "default": "asc",
-              "description": "Order by",
-              "items": {
-                "$ref": "#/components/schemas/OrderEnum",
-              },
-              "type": "array",
-            },
-          },
-        ],
-        "path": "/approval_policies/{approval_policy_id}",
-        "success": {
-          "200": "application/json",
-        },
-        "summary": "Get an approval policy by ID",
-      },
-      {
-        "deprecated": undefined,
-        "description": "Delete an existing approval policy.",
-        "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
-        },
-        "mediaType": undefined,
-        "method": "delete",
-        "name": "deleteApprovalPoliciesId",
-        "parameters": [
-          {
-            "example": "2023-06-04",
-            "in": "header",
-            "name": "x-monite-version",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string",
-            },
-          },
-          {
-            "in": "path",
-            "name": "approval_policy_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-            },
-          },
-          {
-            "description": "Limit of records to delete",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "description": "Limit",
-              "type": "number",
-            },
-          },
-        ],
-        "path": "/approval_policies/{approval_policy_id}",
-        "success": {
-          "200": "application/json",
-        },
-        "summary": "Delete an approval policy",
-      },
-      {
-        "deprecated": undefined,
-        "description": "Update an existing approval policy.",
-        "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
-        },
-        "mediaType": "application/json",
-        "method": "patch",
-        "name": "patchApprovalPoliciesId",
-        "parameters": [
-          {
-            "example": "2023-06-04",
-            "in": "header",
-            "name": "x-monite-version",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string",
-            },
-          },
-          {
-            "in": "path",
-            "name": "approval_policy_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-            },
-          },
-          {
-            "description": "Limit of records to patch",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "description": "Limit",
-              "type": "number",
-            },
-          },
-        ],
-        "path": "/approval_policies/{approval_policy_id}",
-        "success": {
-          "200": "application/json",
-        },
-        "summary": "Update an approval policy",
-      },
-    ],
-    "typeName": "ApprovalPoliciesSrv",
-    "variableName": "approvalPoliciesSrv",
-  },
-  {
-    "fileBaseName": "FilesSrv",
-    "name": "files",
-    "operations": [
-      {
-        "deprecated": undefined,
-        "description": undefined,
-        "errors": {
-          "405": "application/json",
-          "422": "application/json",
-          "default": "application/json",
-        },
-        "mediaType": undefined,
-        "method": "get",
-        "name": "getFiles",
-        "parameters": [
-          {
-            "example": "2023-06-04",
-            "in": "header",
-            "name": "x-monite-version",
-            "required": true,
-            "schema": {
-              "format": "date",
-              "type": "string",
-            },
-          },
-          {
-            "in": "query",
-            "name": "id__in",
-            "required": true,
-            "schema": {
-              "items": {
-                "format": "uuid",
-                "type": "string",
-              },
-              "maxItems": 100,
-              "type": "array",
-            },
-          },
-          {
-            "description": "Page number",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "description": "Page number",
-              "type": "string",
-            },
-          },
-        ],
-        "path": "/files",
-        "success": {
-          "200": "application/json",
-        },
-        "summary": "Get a files by ID",
-      },
-      {
-        "deprecated": undefined,
-        "description": undefined,
-        "errors": {
-          "default": "application/json",
-        },
-        "mediaType": "multipart/form-data",
-        "method": "post",
-        "name": "postFiles",
-        "parameters": undefined,
-        "path": "/files",
-        "success": {
-          "200": "application/json",
-        },
-        "summary": "Upload a files by ID",
-      },
-    ],
-    "typeName": "FilesSrv",
-    "variableName": "filesSrv",
   },
 ]
 `;

--- a/packages/cli/src/lib/open-api/getServiceName.spec.ts
+++ b/packages/cli/src/lib/open-api/getServiceName.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getServiceName } from './getServiceName.js';
 
@@ -11,5 +11,8 @@ describe('getServiceName', () => {
     expect(getServiceName('@fooBar')).toEqual('FooBar');
     expect(getServiceName('$fooBar')).toEqual('FooBar');
     expect(getServiceName('123fooBar')).toEqual('FooBar');
+    expect(getServiceName('foo-bar')).toEqual('FooBar');
+    expect(getServiceName('foo bar')).toEqual('FooBar');
+    expect(getServiceName('foo_bar')).toEqual('FooBar');
   });
 });

--- a/packages/cli/src/lib/open-api/getServiceName.ts
+++ b/packages/cli/src/lib/open-api/getServiceName.ts
@@ -1,13 +1,14 @@
 import camelCase from 'camelcase';
 
 /**
- * Convert the input value to a correct service name. This converts
+ * Convert the input value to the correct service name. This converts
  * the input string to PascalCase.
  */
 export const getServiceName = (value: string): string => {
-    const clean = value
-        .replace(/^[^a-zA-Z]+/g, '')
-        .replace(/[^\w-]+/g, '-')
-        .trim();
-    return camelCase(clean, { pascalCase: true });
+  const clean = value
+    .replace(/^[^a-zA-Z]+/g, '')
+    .replace(/[^\w-]+/g, '-')
+    .trim();
+
+  return camelCase(clean, { pascalCase: true });
 };

--- a/packages/cli/src/lib/open-api/getServiceNamesByEndpoint.spec.ts
+++ b/packages/cli/src/lib/open-api/getServiceNamesByEndpoint.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getEndpointPartIndex,
+  getServiceBaseNameByOperationEndpoint,
+  getServiceNamesByOperationEndpoint,
+} from './getServiceNamesByOperationEndpoint.js';
+
+describe('getEndpointPartIndex(...)', () => {
+  it('returns default index', () => {
+    expect(getEndpointPartIndex('endpoint')).toEqual(0);
+  });
+
+  it('parses valid index', () => {
+    expect(getEndpointPartIndex('endpoint[1]')).toEqual(1);
+    expect(getEndpointPartIndex('endpoint[123]')).toEqual(123);
+  });
+
+  it('should throw on invalid cases', () => {
+    // @ts-expect-error
+    expect(() => getEndpointPartIndex('endpoints')).toThrow();
+    // @ts-expect-error
+    expect(() => getEndpointPartIndex('endpoints[1]')).toThrow();
+    // @ts-expect-error
+    expect(() => getEndpointPartIndex('endpoint[1')).toThrow();
+    // @ts-expect-error
+    expect(() => getEndpointPartIndex('endpoint1]')).toThrow();
+    // @ts-expect-error
+    expect(() => getEndpointPartIndex('[1]')).toThrow();
+  });
+});
+
+describe('getServiceBaseNameByOperationEndpoint(...)', () => {
+  it('returns valid endpoint base name', () => {
+    expect(
+      getServiceBaseNameByOperationEndpoint('foo/bar', 'endpoint')
+    ).toEqual('foo');
+    expect(
+      getServiceBaseNameByOperationEndpoint('foo/bar', 'endpoint[0]')
+    ).toEqual('foo');
+    expect(
+      getServiceBaseNameByOperationEndpoint('foo/bar', 'endpoint[1]')
+    ).toEqual('bar');
+    expect(
+      getServiceBaseNameByOperationEndpoint('foo/bar', 'endpoint[2]')
+    ).toEqual('bar');
+    expect(
+      getServiceBaseNameByOperationEndpoint('foo/bar/baz', 'endpoint[3]')
+    ).toEqual('baz');
+  });
+
+  it('should throw on invalid cases', () => {
+    expect(() =>
+      // @ts-expect-error
+      getServiceBaseNameByOperationEndpoint('foo/bar', '[1]')
+    ).toThrow();
+  });
+});
+
+describe('getServiceNamesByOperationEndpoint(...)', () => {
+  it('returns valid service name', () => {
+    expect(
+      getServiceNamesByOperationEndpoint('foo/bar', 'endpoint', 'fallback')
+    ).toEqual(['Foo']);
+  });
+
+  it('returns fallback service name', () => {
+    expect(
+      getServiceNamesByOperationEndpoint('/', 'endpoint[1]', 'fallback')
+    ).toEqual(['Fallback']);
+  });
+});

--- a/packages/cli/src/lib/open-api/getServiceNamesByEndpoint.spec.ts
+++ b/packages/cli/src/lib/open-api/getServiceNamesByEndpoint.spec.ts
@@ -7,16 +7,14 @@ import {
 } from './getServiceNamesByOperationEndpoint.js';
 
 describe('getEndpointPartIndex(...)', () => {
-  it('returns default index', () => {
-    expect(getEndpointPartIndex('endpoint')).toEqual(0);
-  });
-
   it('parses valid index', () => {
     expect(getEndpointPartIndex('endpoint[1]')).toEqual(1);
     expect(getEndpointPartIndex('endpoint[123]')).toEqual(123);
   });
 
   it('should throw on invalid cases', () => {
+    // @ts-expect-error
+    expect(() => getEndpointPartIndex('endpoint')).toThrow();
     // @ts-expect-error
     expect(() => getEndpointPartIndex('endpoints')).toThrow();
     // @ts-expect-error
@@ -32,9 +30,6 @@ describe('getEndpointPartIndex(...)', () => {
 
 describe('getServiceBaseNameByOperationEndpoint(...)', () => {
   it('returns valid endpoint base name', () => {
-    expect(
-      getServiceBaseNameByOperationEndpoint('foo/bar', 'endpoint')
-    ).toEqual('foo');
     expect(
       getServiceBaseNameByOperationEndpoint('foo/bar', 'endpoint[0]')
     ).toEqual('foo');
@@ -58,12 +53,6 @@ describe('getServiceBaseNameByOperationEndpoint(...)', () => {
 });
 
 describe('getServiceNamesByOperationEndpoint(...)', () => {
-  it('returns valid service name', () => {
-    expect(
-      getServiceNamesByOperationEndpoint('foo/bar', 'endpoint', 'fallback')
-    ).toEqual(['Foo']);
-  });
-
   it('returns fallback service name', () => {
     expect(
       getServiceNamesByOperationEndpoint('/', 'endpoint[1]', 'fallback')

--- a/packages/cli/src/lib/open-api/getServiceNamesByOperationEndpoint.ts
+++ b/packages/cli/src/lib/open-api/getServiceNamesByOperationEndpoint.ts
@@ -1,0 +1,74 @@
+import { getServiceName } from './getServiceName.js';
+
+export type ServiceBaseNameByEndpointOption =
+  | `endpoint[${number}]`
+  | 'endpoint';
+
+export const getServiceNamesByOperationEndpoint = (
+  endpoint: string,
+  format: ServiceBaseNameByEndpointOption,
+  fallbackBaseName: string
+): [string] => {
+  return [
+    getServiceName(
+      getServiceBaseNameByOperationEndpoint(endpoint, format) ??
+        fallbackBaseName
+    ),
+  ];
+};
+
+export const getServiceBaseNameByOperationEndpoint = (
+  endpoint: string,
+  format: ServiceBaseNameByEndpointOption
+): string | undefined => {
+  const endpointParts = endpoint.split('/').filter(Boolean);
+
+  for (
+    let endpointIndex = getEndpointPartIndex(format);
+    endpointIndex >= 0;
+    endpointIndex--
+  ) {
+    const endpointPart = endpointParts[endpointIndex];
+    if (endpointPart) return endpointPart;
+  }
+};
+
+export const getEndpointPartIndex = (
+  endpointOption: ServiceBaseNameByEndpointOption
+) => {
+  if (endpointOption === 'endpoint') return 0;
+
+  const startBracketString = 'endpoint[';
+
+  const endpointIndexStart = endpointOption.indexOf(startBracketString);
+
+  if (endpointIndexStart === -1)
+    throw new Error(
+      `Expected endpoint to start with '${startBracketString}' but got: '${endpointOption}'`
+    );
+
+  const endBracketString = ']';
+  const endpointIndexEnd = endpointOption.indexOf(
+    endBracketString,
+    endpointIndexStart
+  );
+
+  if (endpointIndexEnd === -1)
+    throw new Error(
+      `Expected endpoint to end with '${endBracketString}' but got: '${endpointOption}'`
+    );
+
+  const endpointIndex = parseInt(
+    endpointOption.slice(
+      endpointIndexStart + startBracketString.length,
+      endpointIndexEnd
+    )
+  );
+
+  if (!isFinite(endpointIndex))
+    throw new Error(
+      `Expected endpoint index to be a number but got: '${endpointOption}'`
+    );
+
+  return endpointIndex;
+};

--- a/packages/cli/src/lib/open-api/getServiceNamesByOperationEndpoint.ts
+++ b/packages/cli/src/lib/open-api/getServiceNamesByOperationEndpoint.ts
@@ -1,8 +1,6 @@
 import { getServiceName } from './getServiceName.js';
 
-export type ServiceBaseNameByEndpointOption =
-  | `endpoint[${number}]`
-  | 'endpoint';
+export type ServiceBaseNameByEndpointOption = `endpoint[${number}]`;
 
 export const getServiceNamesByOperationEndpoint = (
   endpoint: string,
@@ -36,8 +34,6 @@ export const getServiceBaseNameByOperationEndpoint = (
 export const getEndpointPartIndex = (
   endpointOption: ServiceBaseNameByEndpointOption
 ) => {
-  if (endpointOption === 'endpoint') return 0;
-
   const startBracketString = 'endpoint[';
 
   const endpointIndexStart = endpointOption.indexOf(startBracketString);

--- a/packages/cli/src/lib/open-api/getServiceNamesByOperationTags.spec.ts
+++ b/packages/cli/src/lib/open-api/getServiceNamesByOperationTags.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getServiceNamesByOperationTags } from './getServiceNamesByOperationTags.js';
+
+describe('getServiceNamesByOperationTags(...)', () => {
+  it('should return all tags', () => {
+    expect(getServiceNamesByOperationTags(['foo', 'bar'], 'fallback')).toEqual([
+      'Foo',
+      'Bar',
+    ]);
+  });
+
+  it('should return fallback tags', () => {
+    expect(getServiceNamesByOperationTags([], 'fallback')).toEqual([
+      'Fallback',
+    ]);
+    expect(getServiceNamesByOperationTags(['--', '__'], 'fallback')).toEqual([
+      'Fallback',
+    ]);
+  });
+});

--- a/packages/cli/src/lib/open-api/getServiceNamesByOperationTags.ts
+++ b/packages/cli/src/lib/open-api/getServiceNamesByOperationTags.ts
@@ -1,0 +1,15 @@
+import { getServiceName } from './getServiceName.js';
+
+export const getServiceNamesByOperationTags = (
+  tags: (string | number | null | undefined)[] | undefined,
+  fallbackBaseName: string
+): string[] => {
+  const filteredTags = tags
+    ?.filter((tag): tag is string => typeof tag === 'string')
+    .map(getServiceName)
+    .filter(Boolean);
+
+  return filteredTags?.length
+    ? filteredTags
+    : [getServiceName(fallbackBaseName)];
+};

--- a/packages/cli/src/lib/open-api/getServices.spec.ts
+++ b/packages/cli/src/lib/open-api/getServices.spec.ts
@@ -16,7 +16,7 @@ describe('getServices', () => {
     expect(
       getServices(
         openAPI,
-        { serviceNameBase: 'endpoint', postfixServices: 'Service' },
+        { serviceNameBase: 'endpoint[0]', postfixServices: 'Service' },
         ['/files/**']
       )
     ).toMatchSnapshot();
@@ -24,7 +24,7 @@ describe('getServices', () => {
 
   it('matches snapshot with "serviceNameBase: endpoint"', () => {
     expect(
-      getServices(openAPI, { serviceNameBase: 'endpoint' })
+      getServices(openAPI, { serviceNameBase: 'endpoint[0]' })
     ).toMatchSnapshot();
   });
 

--- a/packages/cli/src/lib/open-api/getServices.ts
+++ b/packages/cli/src/lib/open-api/getServices.ts
@@ -46,7 +46,7 @@ export const getServices = (
   openApiJson: OpenAPISchemaType,
   {
     postfixServices = 'Service',
-    serviceNameBase = 'endpoint',
+    serviceNameBase = 'endpoint[0]',
   }: { postfixServices?: string; serviceNameBase?: ServiceBaseName } = {},
   servicesGlob = ['**']
 ) => {

--- a/packages/cli/src/lib/open-api/getServices.ts
+++ b/packages/cli/src/lib/open-api/getServices.ts
@@ -4,11 +4,14 @@ import micromatch from 'micromatch';
 
 import { getContentMediaType } from './getContent.js';
 import { getOperationName } from './getOperationName.js';
-import { getServiceName } from './getServiceName.js';
+import {
+  getServiceNamesByOperationEndpoint,
+  ServiceBaseNameByEndpointOption,
+} from './getServiceNamesByOperationEndpoint.js';
 import { getServiceNamesByOperationTags } from './getServiceNamesByOperationTags.js';
 import type { OpenAPISchemaType } from './OpenAPISchemaType.js';
 
-export type ServiceBaseName = 'endpoint' | 'tags';
+export type ServiceBaseName = ServiceBaseNameByEndpointOption | 'tags';
 
 export type Service = {
   name: string;
@@ -99,10 +102,14 @@ export const getServices = (
       const serviceNames =
         serviceNameBase === 'tags'
           ? getServiceNamesByOperationTags(
-            paths[path][method]?.tags,
-            serviceFallbackBaseName
-          )
-          : [getServiceName(path.split('/')[1])];
+              paths[path][method]?.tags,
+              serviceFallbackBaseName
+            )
+          : getServiceNamesByOperationEndpoint(
+              path,
+              serviceNameBase,
+              serviceFallbackBaseName
+            );
 
       for (const name of serviceNames) {
         if (!services.has(name)) {

--- a/packages/cli/src/lib/open-api/getServices.ts
+++ b/packages/cli/src/lib/open-api/getServices.ts
@@ -5,6 +5,7 @@ import micromatch from 'micromatch';
 import { getContentMediaType } from './getContent.js';
 import { getOperationName } from './getOperationName.js';
 import { getServiceName } from './getServiceName.js';
+import { getServiceNamesByOperationTags } from './getServiceNamesByOperationTags.js';
 import type { OpenAPISchemaType } from './OpenAPISchemaType.js';
 
 export type ServiceBaseName = 'endpoint' | 'tags';
@@ -93,9 +94,14 @@ export const getServices = (
         {} as Record<'errors' | 'success', Record<string, string | undefined>>
       );
 
+      const serviceFallbackBaseName = 'Default';
+
       const serviceNames =
         serviceNameBase === 'tags'
-          ? paths[path][method]?.tags?.map(getServiceName) || ['Default']
+          ? getServiceNamesByOperationTags(
+            paths[path][method]?.tags,
+            serviceFallbackBaseName
+          )
           : [getServiceName(path.split('/')[1])];
 
       for (const name of serviceNames) {

--- a/website/docs/codegen/cli.mdx
+++ b/website/docs/codegen/cli.mdx
@@ -76,14 +76,15 @@ comments _(optional)_.
 - **`--postfix-services <string>`:** Customize the generated service names with a specific postfix _(optional, default: `Service`)_.
   - Example: `--postfix-services Endpoint` will generate `services/UserEndpoint.ts` instead of `services/UserService.ts`.
 using ECMAScript modules when TypeScript's _--moduleResolution_ is `node16` or `nodenext` _(optional)_.
-- **`--service-name-base <endpoint | tags>`:** Use OpenAPI Operation `endpoint` or `tags` as the base name of the service _(optional, default: `endpoint`)_.
+- **`--service-name-base <endpoint[<index>] | tags>`:** Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: `/0/1/2`) or `tags` as the base name of the service. _(optional, default: `endpoint[0]`)_.
   - Examples:
-    - `--service-name-base endpoint` will generate services based on the OpenAPI Operation endpoint.
+    - `--service-name-base endpoint[0]` generates `services/FooService.ts`. from endpoint `/foo/bar/baz`
+    - `--service-name-base endpoint[1]` generates `services/BarService.ts`. from endpoint `/foo/bar/baz`
+    - `--service-name-base endpoint[2]` generates `services/BarService.ts`. from endpoint `/foo/bar` _(if the endpoint is shorter than the index, the last part is used)_
     - `--service-name-base tags` will generate services based on the OpenAPI Operation tags instead of the endpoint.
-      - If multiple tags are present for the operation, similar services will be created for each tag.
-      - If there are no tags for the operation, the services will be created under the `default` tag.
+      - If multiple tags are present for the operation, similar services will be created for each tag. Operation with `tags: [Foo, Bar]` will generate `services/FooService.ts` and `services/BarService.ts`.
+      - If there are no tags for the operation, the services will be created under the `default` tag. Operation with empty `tags: []` will generate `services/DefaultService.ts`.
 - **`--explicit-import-extensions`:** Include explicit `.js` extensions in all import statements. Ideal for projects
-
 - **`-h, --help`:** Display help for the command (optional).
 
 ## In-project Setup


### PR DESCRIPTION
Added support for specifying a specific segment of an OpenAPI Operation's endpoint path (as a Services group) by using the `--service-name-base endpoint[<index>]` option. This update allows more granular control over service naming based on individual path segments.

Removed the previous default behavior that only allowed using the first segment of the endpoint path with `--service-name-base endpoint`.

This change enables customization of the base name for service generation based on different endpoint segments.