### PR TITLE
chore(cli): update `getServices(...)` tests

### DIFF
--- a/packages/cli/src/lib/open-api/__fixtures__/openapi.json
+++ b/packages/cli/src/lib/open-api/__fixtures__/openapi.json
@@ -12,7 +12,7 @@
   "paths": {
     "/approval_policies/{approval_policy_id}": {
       "get": {
-        "tags": ["Approval policies", "Main"],
+        "tags": [],
         "summary": "Get an approval policy by ID",
         "description": "Retrieve a specific approval policy.",
         "operationId": "get_approval_policies_id",

--- a/packages/cli/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
+++ b/packages/cli/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
@@ -1,5 +1,599 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
+[
+  {
+    "fileBaseName": "ApprovalPoliciesService",
+    "name": "approvalPolicies",
+    "operations": [
+      {
+        "deprecated": undefined,
+        "description": "Retrieve a specific approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "get",
+        "name": "getApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Order by",
+            "in": "query",
+            "name": "items_order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "description": "Order by",
+              "items": {
+                "$ref": "#/components/schemas/OrderEnum",
+              },
+              "type": "array",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Get an approval policy by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": "Delete an existing approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit of records to delete",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Limit",
+              "type": "number",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete an approval policy",
+      },
+      {
+        "deprecated": undefined,
+        "description": "Update an existing approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": "application/json",
+        "method": "patch",
+        "name": "patchApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit of records to patch",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Limit",
+              "type": "number",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Update an approval policy",
+      },
+    ],
+    "typeName": "ApprovalPoliciesService",
+    "variableName": "approvalPoliciesService",
+  },
+  {
+    "fileBaseName": "FilesService",
+    "name": "files",
+    "operations": [
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "405": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "get",
+        "name": "getFiles",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "id__in",
+            "required": true,
+            "schema": {
+              "items": {
+                "format": "uuid",
+                "type": "string",
+              },
+              "maxItems": 100,
+              "type": "array",
+            },
+          },
+          {
+            "description": "Page number",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "description": "Page number",
+              "type": "string",
+            },
+          },
+        ],
+        "path": "/files",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Get a files by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": "multipart/form-data",
+        "method": "post",
+        "name": "postFiles",
+        "parameters": undefined,
+        "path": "/files",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Upload a files by ID",
+      },
+    ],
+    "typeName": "FilesService",
+    "variableName": "filesService",
+  },
+]
+`;
+
+exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
+[
+  {
+    "fileBaseName": "ApprovalPoliciesService",
+    "name": "approvalPolicies",
+    "operations": [
+      {
+        "deprecated": undefined,
+        "description": "Delete an existing approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit of records to delete",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Limit",
+              "type": "number",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete an approval policy",
+      },
+      {
+        "deprecated": undefined,
+        "description": "Update an existing approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": "application/json",
+        "method": "patch",
+        "name": "patchApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit of records to patch",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Limit",
+              "type": "number",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Update an approval policy",
+      },
+    ],
+    "typeName": "ApprovalPoliciesService",
+    "variableName": "approvalPoliciesService",
+  },
+  {
+    "fileBaseName": "MainService",
+    "name": "main",
+    "operations": [
+      {
+        "deprecated": undefined,
+        "description": "Delete an existing approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit of records to delete",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Limit",
+              "type": "number",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete an approval policy",
+      },
+      {
+        "deprecated": undefined,
+        "description": "Update an existing approval policy.",
+        "errors": {
+          "401": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": "application/json",
+        "method": "patch",
+        "name": "patchApprovalPoliciesId",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "approval_policy_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit of records to patch",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Limit",
+              "type": "number",
+            },
+          },
+        ],
+        "path": "/approval_policies/{approval_policy_id}",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Update an approval policy",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "405": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "get",
+        "name": "getFiles",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "id__in",
+            "required": true,
+            "schema": {
+              "items": {
+                "format": "uuid",
+                "type": "string",
+              },
+              "maxItems": 100,
+              "type": "array",
+            },
+          },
+          {
+            "description": "Page number",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "description": "Page number",
+              "type": "string",
+            },
+          },
+        ],
+        "path": "/files",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Get a files by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": "multipart/form-data",
+        "method": "post",
+        "name": "postFiles",
+        "parameters": undefined,
+        "path": "/files",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Upload a files by ID",
+      },
+    ],
+    "typeName": "MainService",
+    "variableName": "mainService",
+  },
+  {
+    "fileBaseName": "FilesService",
+    "name": "files",
+    "operations": [
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "405": "application/json",
+          "422": "application/json",
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "get",
+        "name": "getFiles",
+        "parameters": [
+          {
+            "example": "2023-06-04",
+            "in": "header",
+            "name": "x-monite-version",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "id__in",
+            "required": true,
+            "schema": {
+              "items": {
+                "format": "uuid",
+                "type": "string",
+              },
+              "maxItems": 100,
+              "type": "array",
+            },
+          },
+          {
+            "description": "Page number",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "description": "Page number",
+              "type": "string",
+            },
+          },
+        ],
+        "path": "/files",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Get a files by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": "multipart/form-data",
+        "method": "post",
+        "name": "postFiles",
+        "parameters": undefined,
+        "path": "/files",
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Upload a files by ID",
+      },
+    ],
+    "typeName": "FilesService",
+    "variableName": "filesService",
+  },
+]
+`;
+
 exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
 [
   {

--- a/packages/cli/src/lib/open-api/getServices.spec.ts
+++ b/packages/cli/src/lib/open-api/getServices.spec.ts
@@ -13,6 +13,22 @@ describe('getServices', () => {
   });
 
   it('matches snapshot with custom `servicesGlob`', () => {
-    expect(getServices(openAPI, {}, ['/files/**'])).toMatchSnapshot();
+    expect(
+      getServices(
+        openAPI,
+        { serviceNameBase: 'endpoint', postfixServices: 'Service' },
+        ['/files/**']
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('matches snapshot with "serviceNameBase: endpoint"', () => {
+    expect(
+      getServices(openAPI, { serviceNameBase: 'endpoint' })
+    ).toMatchSnapshot();
+  });
+
+  it('matches snapshot with "serviceNameBase: tags"', () => {
+    expect(getServices(openAPI, { serviceNameBase: 'tags' })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Added `getServices(...)` tests to cover `serviceNameBase: endpoint | tags` option