### PR TITLE
chore(website): add `paths` to the "Deploy to GitHub Pages" workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -2,6 +2,12 @@ name: Deploy to GitHub Pages
 
 on:
   push:
+    paths:
+      - 'website/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - 'tsconfig.json'
+      - '.yarnrc.yml'
     branches:
       - main
     # Review gh actions docs if you want to further define triggers, paths, etc


### PR DESCRIPTION
Preventing Documentation Website from being deployed if no changes have been made to the site.