### PR TITLE
fix(openapi-typescript-plugin): remove `.ts` extension from import paths by default

### DIFF
--- a/.changeset/funny-terms-pretend.md
+++ b/.changeset/funny-terms-pretend.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/openapi-typescript-plugin": patch
+---
+
+Default behavior now removes `.ts` extension from import paths. This behavior can be overridden for the `@openapi-qraft/tanstack-query-react-plugin` using the `--openapi-types-import-path <path>` option, which allows specifying the full import path, including the `.ts` extension.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,17 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@openapi-qraft/e2e": "1.0.0",
+    "@openapi-qraft/cli": "1.10.0",
+    "@openapi-qraft/eslint-config": "1.0.0",
+    "@openapi-qraft/openapi-typescript-plugin": "1.0.2",
+    "@openapi-qraft/plugin": "1.10.0",
+    "@openapi-qraft/react": "1.10.0",
+    "@openapi-qraft/tanstack-query-react-plugin": "1.10.0",
+    "@openapi-qraft/test-fixtures": "1.0.0",
+    "playground": "0.0.14",
+    "openapi-qraft-website": "0.0.0"
+  },
+  "changesets": []
+}

--- a/packages/openapi-typescript-plugin/src/plugin.ts
+++ b/packages/openapi-typescript-plugin/src/plugin.ts
@@ -94,10 +94,24 @@ export const plugin: QraftCommandPlugin = {
     command.hook('preAction', (thisCommand) => {
       // Do not override if a custom value already exists
       if (!command.getOptionValue('openapiTypesImportPath')) {
+        let openapiTypesFileName = thisCommand.getOptionValue(
+          'openapiTypesFileName'
+        );
+
+        if (
+          thisCommand.getOptionValueSource('openapiTypesFileName') === 'default'
+        ) {
+          openapiTypesFileName = openapiTypesFileName.slice(
+            0,
+            openapiTypesFileName.indexOf('.')
+          );
+        }
+
+        // Set value to `--openapi-types-import-path` option
         thisCommand.setOptionValue(
           'openapiTypesImportPath',
           createOpenapiTypesImportPath(
-            thisCommand.getOptionValue('openapiTypesFileName'),
+            openapiTypesFileName,
             thisCommand.getOptionValue('explicitImportExtensions')
           )
         );


### PR DESCRIPTION
This change removes the `.ts` extension from import paths by default when using the OpenAPI TypeScript plugin. This behavior can be overridden for the `@openapi-qraft/tanstack-query-react-plugin` using the `--openapi-types-import-path <path>` option, which allows specifying the full import path, including the `.ts` extension.