### PR TITLE
fix(tanstack-query-react-plugin): remove `as const` from `services`

### DIFF
--- a/.changeset/nice-ladybugs-act.md
+++ b/.changeset/nice-ladybugs-act.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+---
+
+Removed `as const` from Services variable for compatibility with older TypeScript versions.

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -66,4 +66,4 @@ export const approvalPoliciesService: {
             security: ["HTTPBearer"]
         }
     }
-} as const;
+};

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/services/FilesService.ts.snapshot.ts
@@ -56,4 +56,4 @@ export const filesService: {
             security: ["HTTPBearer"]
         }
     }
-} as const;
+};

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -324,15 +324,9 @@ const getServiceVariableFactory = (
           factory.createIdentifier(variableName),
           undefined,
           getServiceVariableTypeFactory({ typeName }),
-          factory.createAsExpression(
-            factory.createObjectLiteralExpression(
-              operations.map(getServiceVariablePropertyFactory),
-              true
-            ),
-            factory.createTypeReferenceNode(
-              factory.createIdentifier('const'),
-              undefined
-            )
+          factory.createObjectLiteralExpression(
+            operations.map(getServiceVariablePropertyFactory),
+            true
           )
         ),
       ],


### PR DESCRIPTION
This PR removes `as const` from the `services` variable to ensure compatibility with older TypeScript versions. This change prevents potential errors and improves the library's accessibility.