### PR TITLE
feat: improve service output type for library distribution

### DIFF
--- a/.changeset/chilled-bobcats-sip.md
+++ b/.changeset/chilled-bobcats-sip.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/tanstack-query-react-plugin": patch
+---
+
+Refactor the service output type to a flatter structure. This improves TypeScript compilation and enables easier distribution of the code as a library.

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -42,7 +42,34 @@ export interface ApprovalPoliciesService {
     }, NonNullable<paths["/approval_policies/{approval_policy_id}"]["patch"]["requestBody"]>["content"]["application/json"], paths["/approval_policies/{approval_policy_id}"]["patch"]["responses"]["200"]["content"]["application/json"], paths["/approval_policies/{approval_policy_id}"]["patch"]["parameters"], paths["/approval_policies/{approval_policy_id}"]["patch"]["responses"]["401"]["content"]["application/json"] | paths["/approval_policies/{approval_policy_id}"]["patch"]["responses"]["422"]["content"]["application/json"] | paths["/approval_policies/{approval_policy_id}"]["patch"]["responses"]["default"]["content"]["application/json"]>;
 }
 export const approvalPoliciesService: {
-    [key in keyof ApprovalPoliciesService]: Pick<ApprovalPoliciesService[key], "schema">;
+    getApprovalPoliciesId: {
+        schema: {
+            method: "get";
+            url: "/approval_policies/{approval_policy_id}";
+            security: [
+                "partnerToken"
+            ];
+        };
+    };
+    deleteApprovalPoliciesId: {
+        schema: {
+            method: "delete";
+            url: "/approval_policies/{approval_policy_id}";
+            security: [
+                "HTTPBearer"
+            ];
+        };
+    };
+    patchApprovalPoliciesId: {
+        schema: {
+            method: "patch";
+            url: "/approval_policies/{approval_policy_id}";
+            mediaType: "application/json";
+            security: [
+                "HTTPBearer"
+            ];
+        };
+    };
 } = {
     getApprovalPoliciesId: {
         schema: {

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/services/FilesService.ts.snapshot.ts
@@ -33,7 +33,31 @@ export interface FilesService {
     }, paths["/files/list"]["get"]["responses"]["200"]["content"]["application/json"], paths["/files/list"]["get"]["parameters"], paths["/files/list"]["get"]["responses"]["default"]["content"]["application/json"]>;
 }
 export const filesService: {
-    [key in keyof FilesService]: Pick<FilesService[key], "schema">;
+    getFiles: {
+        schema: {
+            method: "get";
+            url: "/files";
+            security: [
+                "HTTPBearer"
+            ];
+        };
+    };
+    postFiles: {
+        schema: {
+            method: "post";
+            url: "/files";
+            mediaType: "multipart/form-data";
+        };
+    };
+    getFileList: {
+        schema: {
+            method: "get";
+            url: "/files/list";
+            security: [
+                "HTTPBearer"
+            ];
+        };
+    };
 } = {
     getFiles: {
         schema: {

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -313,7 +313,7 @@ const getOperationParametersFactory = (operation: ServiceOperation) => {
 };
 
 const getServiceVariableFactory = (
-  { typeName, variableName }: { typeName: string; variableName: string },
+  { variableName }: { variableName: string },
   operations: ServiceOperation[]
 ) => {
   return factory.createVariableStatement(
@@ -323,7 +323,9 @@ const getServiceVariableFactory = (
         factory.createVariableDeclaration(
           factory.createIdentifier(variableName),
           undefined,
-          getServiceVariableTypeFactory({ typeName }),
+          factory.createTypeLiteralNode(
+            operations.map(getServiceVariableTypeFactory)
+          ),
           factory.createObjectLiteralExpression(
             operations.map(getServiceVariablePropertyFactory),
             true
@@ -335,37 +337,19 @@ const getServiceVariableFactory = (
   );
 };
 
-const getServiceVariableTypeFactory = ({ typeName }: { typeName: string }) => {
-  return factory.createMappedTypeNode(
+const getServiceVariableTypeFactory = (operation: ServiceOperation) => {
+  return factory.createPropertySignature(
     undefined,
-    factory.createTypeParameterDeclaration(
-      undefined,
-      factory.createIdentifier('key'),
-      factory.createTypeOperatorNode(
-        ts.SyntaxKind.KeyOfKeyword,
-        factory.createTypeReferenceNode(
-          factory.createIdentifier(typeName),
-          undefined
-        )
+    factory.createIdentifier(operation.name),
+    undefined,
+    factory.createTypeLiteralNode([
+      factory.createPropertySignature(
+        undefined,
+        factory.createIdentifier('schema'),
+        undefined,
+        getOperationSchemaFactory(operation)
       ),
-      undefined
-    ),
-    undefined,
-    undefined,
-    factory.createTypeReferenceNode(factory.createIdentifier('Pick'), [
-      factory.createIndexedAccessTypeNode(
-        factory.createTypeReferenceNode(
-          factory.createIdentifier(typeName),
-          undefined
-        ),
-        factory.createTypeReferenceNode(
-          factory.createIdentifier('key'),
-          undefined
-        )
-      ),
-      factory.createLiteralTypeNode(factory.createStringLiteral('schema')),
-    ]),
-    undefined
+    ])
   );
 };
 


### PR DESCRIPTION
This PR refactors the service output type to a flatter structure. This change primarily aims to:

* **Improve TypeScript compilation:** The previous nested structure posed challenges for TypeScript compilation, especially when distributing the code as a library. 