### PR TITLE
chore(react-client): Use a single source `d.ts` file for all module formats

### DIFF
--- a/.changeset/friendly-schools-learn.md
+++ b/.changeset/friendly-schools-learn.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': patch
+---
+
+Use a single source `d.ts` file for all module formats

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -3,7 +3,7 @@
   "version": "1.11.0-beta.1",
   "description": "API client for React, providing type-safe requests and dynamic Tanstack Query React Hooks via a modular, Proxy-based architecture.",
   "scripts": {
-    "build": "rimraf dist/ && tsup --config tsup.config.ts",
+    "build": "rimraf dist/ && tsup --config tsup.config.ts && tsc --project tsconfig.build.json --emitDeclarationOnly",
     "dev": "rimraf dist/ && tsc --project tsconfig.build.json --watch --outDir ./dist/esm",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -49,16 +49,16 @@
     "!src/tests/**"
   ],
   "type": "module",
-  "types": "dist/cjs/index.d.cts",
+  "types": "dist/types/index.d.ts",
   "main": "dist/cjs/index.cjs",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.ts",
+        "types": "./dist/types/index.d.ts",
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "types": "./dist/cjs/index.d.cts",
+        "types": "./dist/types/index.d.ts",
         "default": "./dist/cjs/index.cjs"
       }
     },

--- a/packages/react-client/tsconfig.build.json
+++ b/packages/react-client/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    "declarationDir": "dist/types",
     "declaration": true,
     "declarationMap": true,
   },

--- a/packages/react-client/tsup.config.ts
+++ b/packages/react-client/tsup.config.ts
@@ -7,7 +7,7 @@ const tsupBaseOptions: Options = {
   entry: ['src/index.ts'],
   target: ['chrome91', 'firefox90', 'edge91', 'safari15', 'ios15', 'opera77'],
   tsconfig: 'tsconfig.build.json',
-  dts: true,
+  dts: false,
   sourcemap: true,
   clean: true,
   banner: {


### PR DESCRIPTION
This PR improves the maintainability of our TypeScript type definitions. Instead of having separate `d.ts` files for each module format (ESM, CJS), we now generate all definitions from a single source `d.ts` file. This ensures consistency across module formats and reduces the possibility of discrepancies between the definitions.
