### PR TITLE
feat: make `requestFn` optional

### DIFF
--- a/.changeset/great-balloons-own.md
+++ b/.changeset/great-balloons-own.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': minor
+---
+
+feat: make `requestFn` optional if `queryFn` or `mutationFn` is specified in hooks.

--- a/packages/react-client/src/callbacks/useMutation.ts
+++ b/packages/react-client/src/callbacks/useMutation.ts
@@ -50,8 +50,6 @@ export const useMutation: <
     );
 
   const contextValue = useContext(qraftOptions?.context ?? QraftContext);
-  if (!contextValue?.requestFn)
-    throw new Error(`QraftContext.request not found`);
 
   const mutationKey =
     options && 'mutationKey' in options
@@ -69,6 +67,9 @@ export const useMutation: <
         options?.mutationFn ??
         (parameters
           ? function (bodyPayload) {
+              if (!contextValue?.requestFn)
+                throw new Error(`QraftContext.requestFn not found`);
+
               return contextValue.requestFn(schema, {
                 parameters,
                 baseUrl: contextValue.baseUrl,
@@ -76,6 +77,9 @@ export const useMutation: <
               });
             }
           : function (parametersAndBodyPayload) {
+              if (!contextValue?.requestFn)
+                throw new Error(`QraftContext.requestFn not found`);
+
               const { body, ...parameters } = parametersAndBodyPayload as {
                 body: unknown;
               };

--- a/packages/react-client/src/callbacks/useQueries.ts
+++ b/packages/react-client/src/callbacks/useQueries.ts
@@ -24,8 +24,6 @@ export const useQueries: (
   const [options, queryClientByArg] = args;
 
   const contextValue = useContext(qraftOptions?.context ?? QraftContext);
-  if (!contextValue?.requestFn)
-    throw new Error(`QraftContext.requestFn not found`);
 
   return useQueriesTanstack(
     {
@@ -51,6 +49,9 @@ export const useQueries: (
           queryFn:
             optionsWithQueryKey.queryFn ??
             function ({ queryKey: [, queryParams], signal, meta }) {
+              if (!contextValue?.requestFn)
+                throw new Error(`QraftContext.requestFn not found`);
+
               return contextValue.requestFn(schema, {
                 parameters: queryParams as never,
                 baseUrl: contextValue.baseUrl,

--- a/packages/react-client/src/callbacks/useSuspenseQueries.ts
+++ b/packages/react-client/src/callbacks/useSuspenseQueries.ts
@@ -28,8 +28,6 @@ export const useSuspenseQueries: (
   const [options, queryClientByArg] = args;
 
   const contextValue = useContext(qraftOptions?.context ?? QraftContext);
-  if (!contextValue?.requestFn)
-    throw new Error(`QraftContext.requestFn not found`);
 
   return useSuspenseQueriesTanstack(
     {
@@ -55,6 +53,9 @@ export const useSuspenseQueries: (
           queryFn:
             optionsWithQueryKey.queryFn ??
             function ({ queryKey: [, queryParams], signal, meta }) {
+              if (!contextValue?.requestFn)
+                throw new Error(`QraftContext.requestFn not found`);
+
               return contextValue.requestFn(schema, {
                 parameters: queryParams as never,
                 baseUrl: contextValue.baseUrl,

--- a/packages/react-client/src/lib/useComposeUseQueryOptions.ts
+++ b/packages/react-client/src/lib/useComposeUseQueryOptions.ts
@@ -27,13 +27,14 @@ export function useComposeUseQueryOptions(
   const [parameters, options, queryClient] = args;
 
   const contextValue = useContext(qraftOptions?.context ?? QraftContext);
-  if (!contextValue?.requestFn)
-    throw new Error(`QraftContext.requestFn not found`);
 
   const queryFn =
     options?.queryFn ??
     // @ts-expect-error - Too complex to type
     function ({ queryKey: [, queryParams], signal, meta, pageParam }) {
+      if (!contextValue?.requestFn)
+        throw new Error(`QraftContext.requestFn not found`);
+
       return contextValue.requestFn(schema, {
         // @ts-expect-error - Too complex to type
         parameters: infinite


### PR DESCRIPTION
Make `requestFn` optional if `queryFn` or `mutationFn` is specified in hooks.