### PR TITLE
fix(`@openapi-graft/react package`): typing issues

### DIFF
--- a/.changeset/fuzzy-pugs-grow.md
+++ b/.changeset/fuzzy-pugs-grow.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': patch
+---
+
+Fixed output type for `useQueries(...)` and `useSuspenseQueries(...)`.

--- a/.changeset/gorgeous-wasps-trade.md
+++ b/.changeset/gorgeous-wasps-trade.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': patch
+---
+
+Fixed typing for `select(...)` in `useQuery(...)` and `useSuspenseQuery`.

--- a/.changeset/pretty-carrots-kick.md
+++ b/.changeset/pretty-carrots-kick.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Fixed typing for `select(...)` in `useInfiniteQuery(...)` and `useSuspenseInfiniteQuery(...)`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for generating typed Tanstack Query React Hooks and services from OpenAPI Schemas, improving type safety in React apps",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "dev": "yarn build --watch",
+    "dev": "yarn build --watch --noEmitOnError false",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",

--- a/packages/openapi-typescript-plugin/package.json
+++ b/packages/openapi-typescript-plugin/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "dev": "yarn build --watch",
+    "dev": "yarn build --watch --noEmitOnError false",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "dev": "yarn build --watch",
+    "dev": "yarn build --watch --noEmitOnError false",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -4,7 +4,7 @@
   "description": "API client for React, providing type-safe requests and dynamic Tanstack Query React Hooks via a modular, Proxy-based architecture.",
   "scripts": {
     "build": "NODE_ENV=production rollup --config rollup.config.mjs && tsc --project tsconfig.build.json --emitDeclarationOnly",
-    "dev": "rimraf dist/ && tsc --project tsconfig.build.json --watch --outDir ./dist/esm",
+    "dev": "rimraf dist/ && tsc --project tsconfig.build.json --watch --outDir ./dist/esm --noEmitOnError false",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",

--- a/packages/react-client/src/callbacks/useQueries.ts
+++ b/packages/react-client/src/callbacks/useQueries.ts
@@ -38,7 +38,6 @@ export const useQueries: (
                   },
                   queryOptions
                 );
-                // @ts-expect-error - `parameters` is not inferred as a property of `queryOptionsCopy`
                 delete queryOptionsCopy.parameters;
                 return queryOptionsCopy;
               })()

--- a/packages/react-client/src/callbacks/useSuspenseQueries.ts
+++ b/packages/react-client/src/callbacks/useSuspenseQueries.ts
@@ -42,7 +42,6 @@ export const useSuspenseQueries: (
                   },
                   queryOptions
                 );
-                // @ts-expect-error - `parameters` is not inferred as a property of `queryOptionsCopy`
                 delete queryOptionsCopy.parameters;
                 return queryOptionsCopy;
               })()

--- a/packages/react-client/src/service-operation/ServiceOperation.ts
+++ b/packages/react-client/src/service-operation/ServiceOperation.ts
@@ -27,7 +27,7 @@ import type { ServiceOperationUseQueries } from './ServiceOperationUseQueries.js
 import type { ServiceOperationUseQuery } from './ServiceOperationUseQuery.js';
 import type { ServiceOperationUseSuspenseInfiniteQuery } from './ServiceOperationUseSuspenseInfiniteQuery.js';
 import type { ServiceOperationUseSuspenseQueries } from './ServiceOperationUseSuspenseQueries.js';
-import type { ServiceOperationUseSuspenseQueryQuery } from './ServiceOperationUseSuspenseQueryQuery.js';
+import type { ServiceOperationUseSuspenseQuery } from './ServiceOperationUseSuspenseQuery.js';
 
 export interface ServiceOperationQuery<
   TSchema extends { url: string; method: string },
@@ -38,7 +38,7 @@ export interface ServiceOperationQuery<
     ServiceOperationUseQueries<TSchema, TData, TParams, TError>,
     ServiceOperationUseSuspenseQueries<TSchema, TData, TParams, TError>,
     ServiceOperationUseInfiniteQuery<TSchema, TData, TParams, TError>,
-    ServiceOperationUseSuspenseQueryQuery<TSchema, TData, TParams, TError>,
+    ServiceOperationUseSuspenseQuery<TSchema, TData, TParams, TError>,
     ServiceOperationUseSuspenseInfiniteQuery<TSchema, TData, TParams, TError>,
     ServiceOperationUseIsFetchingQueries<TSchema, TData, TParams, TError>,
     ServiceOperationQueryFn<TSchema, TData, TParams>,

--- a/packages/react-client/src/service-operation/ServiceOperationUseInfiniteQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseInfiniteQuery.ts
@@ -16,7 +16,7 @@ import type { ServiceOperationInfiniteQueryKey } from './ServiceOperationKey.js'
 
 export interface ServiceOperationUseInfiniteQuery<
   TSchema extends { url: string; method: string },
-  TData,
+  TQueryFnData,
   TParams = {},
   TError = DefaultError,
 > {
@@ -24,11 +24,11 @@ export interface ServiceOperationUseInfiniteQuery<
     parameters: TQueryKeyParams
   ): ServiceOperationInfiniteQueryKey<TSchema, TQueryKeyParams>;
 
-  useInfiniteQuery<TPageParam extends TParams>(
+  useInfiniteQuery<TPageParam extends TParams, TData = TQueryFnData>(
     parameters: TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
     options: Omit<
       UndefinedInitialDataInfiniteOptions<
-        TData,
+        TQueryFnData,
         TError,
         OperationInfiniteData<TData, TParams>,
         ServiceOperationInfiniteQueryKey<TSchema, TParams>,
@@ -39,18 +39,21 @@ export interface ServiceOperationUseInfiniteQuery<
       | 'getNextPageParam'
       | 'initialPageParam'
     > &
-      InfiniteQueryPageParamsOptions<TData, PartialParameters<TPageParam>>,
+      InfiniteQueryPageParamsOptions<
+        TQueryFnData,
+        PartialParameters<TPageParam>
+      >,
     queryClient?: QueryClient
   ): UseInfiniteQueryResult<
     OperationInfiniteData<TData, TParams>,
     TError | Error
   >;
 
-  useInfiniteQuery<TPageParam extends TParams>(
+  useInfiniteQuery<TPageParam extends TParams, TData = TQueryFnData>(
     parameters: TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
     options: Omit<
       DefinedInitialDataInfiniteOptions<
-        TData,
+        TQueryFnData,
         TError,
         OperationInfiniteData<TData, TParams>,
         ServiceOperationInfiniteQueryKey<TSchema, TParams>,
@@ -61,7 +64,10 @@ export interface ServiceOperationUseInfiniteQuery<
       | 'getNextPageParam'
       | 'initialPageParam'
     > &
-      InfiniteQueryPageParamsOptions<TData, PartialParameters<TPageParam>>,
+      InfiniteQueryPageParamsOptions<
+        TQueryFnData,
+        PartialParameters<TPageParam>
+      >,
     queryClient?: QueryClient
   ): DefinedUseInfiniteQueryResult<
     OperationInfiniteData<TData, TParams>,

--- a/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
@@ -10,7 +10,7 @@ import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
 export interface ServiceOperationUseQuery<
   TSchema extends { url: string; method: string },
-  TData,
+  TQueryFnData,
   TParams = {},
   TError = DefaultError,
 > {
@@ -18,11 +18,11 @@ export interface ServiceOperationUseQuery<
     parameters?: QueryKeyParams
   ): ServiceOperationQueryKey<TSchema, QueryKeyParams>;
 
-  useQuery(
+  useQuery<TData = TQueryFnData>(
     parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
     options?: Omit<
       UndefinedInitialDataOptions<
-        TData,
+        TQueryFnData,
         TError,
         TData,
         ServiceOperationQueryKey<TSchema, TParams>
@@ -32,11 +32,11 @@ export interface ServiceOperationUseQuery<
     queryClient?: QueryClient
   ): UseQueryResult<TData, TError | Error>;
 
-  useQuery(
+  useQuery<TData = TQueryFnData>(
     parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
     options: Omit<
       DefinedInitialDataOptions<
-        TData,
+        TQueryFnData,
         TError,
         TData,
         ServiceOperationQueryKey<TSchema, TParams>

--- a/packages/react-client/src/service-operation/ServiceOperationUseSuspenseInfiniteQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseSuspenseInfiniteQuery.ts
@@ -14,18 +14,18 @@ import type { ServiceOperationInfiniteQueryKey } from './ServiceOperationKey.js'
 
 export interface ServiceOperationUseSuspenseInfiniteQuery<
   TSchema extends { url: string; method: string },
-  TData,
+  TQueryFnData,
   TParams = {},
   TError = DefaultError,
 > {
-  useSuspenseInfiniteQuery<TPageParam extends TParams>(
+  useSuspenseInfiniteQuery<TPageParam extends TParams, TData = TQueryFnData>(
     parameters: TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
     options: Omit<
       UseSuspenseInfiniteQueryOptions<
-        TData,
+        TQueryFnData,
         TError,
         OperationInfiniteData<TData, TParams>,
-        TData,
+        TQueryFnData,
         ServiceOperationInfiniteQueryKey<TSchema, TParams>,
         PartialParameters<TPageParam>
       >,
@@ -34,7 +34,10 @@ export interface ServiceOperationUseSuspenseInfiniteQuery<
       | 'getNextPageParam'
       | 'initialPageParam'
     > &
-      InfiniteQueryPageParamsOptions<TData, PartialParameters<TPageParam>>,
+      InfiniteQueryPageParamsOptions<
+        TQueryFnData,
+        PartialParameters<TPageParam>
+      >,
     queryClient?: QueryClient
   ): UseSuspenseInfiniteQueryResult<
     OperationInfiniteData<TData, TParams>,

--- a/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQueries.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQueries.ts
@@ -1,40 +1,59 @@
 import type { DefaultError, QueryClient } from '@tanstack/query-core';
 import type {
-  UseSuspenseQueryOptions,
+  UseQueryOptions,
   UseSuspenseQueryResult,
 } from '@tanstack/react-query';
 
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
+type UseQueryOptionsForUseSuspenseQuery<
+  TSchema extends { url: string; method: string },
+  TParams,
+  TQueryFnData,
+  TError,
+  TData = TQueryFnData,
+> = Omit<
+  UseQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    ServiceOperationQueryKey<TSchema, TParams>
+  >,
+  'enabled' | 'throwOnError' | 'placeholderData' | 'queryKey'
+> &
+  (
+    | {
+        parameters: TParams;
+        queryKey?: never;
+      }
+    | {
+        queryKey: ServiceOperationQueryKey<TSchema, TParams>;
+        parameters?: never;
+      }
+  );
+
 export interface ServiceOperationUseSuspenseQueries<
   TSchema extends { url: string; method: string },
-  TData,
+  TQueryFnData,
   TParams = {},
   TError = DefaultError,
 > {
   useSuspenseQueries<
-    TCombinedResult = Array<UseSuspenseQueryResult<TData, TError>>,
+    T extends Array<
+      UseQueryOptionsForUseSuspenseQuery<TSchema, TParams, TQueryFnData, TError>
+    >,
+    TCombinedResult = Array<UseSuspenseQueryResult<TQueryFnData, TError>>,
   >(
     options: {
-      queries: ReadonlyArray<
-        Omit<
-          UseSuspenseQueryOptions<
-            TData,
-            TError,
-            TData,
-            ServiceOperationQueryKey<TSchema, TParams>
-          >,
-          'queryKey'
-        > &
-          (
-            | { parameters: TParams; queryKey?: never }
-            | { queryKey: ServiceOperationQueryKey<TSchema, TParams> }
-          )
-      >;
+      queries: T;
       combine?: (
-        results: Array<UseSuspenseQueryResult<TData, TError>>
+        results: Array<
+          WithOptional<UseSuspenseQueryResult<TQueryFnData, TError>, 'data'>
+        >
       ) => TCombinedResult;
     },
     queryClient?: QueryClient
   ): TCombinedResult;
 }
+
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQuery.ts
@@ -6,7 +6,7 @@ import type {
 
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
-export interface ServiceOperationUseSuspenseQueryQuery<
+export interface ServiceOperationUseSuspenseQuery<
   TSchema extends { url: string; method: string },
   TQueryFnData,
   TParams = {},

--- a/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQueryQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQueryQuery.ts
@@ -8,15 +8,15 @@ import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
 export interface ServiceOperationUseSuspenseQueryQuery<
   TSchema extends { url: string; method: string },
-  TData,
+  TQueryFnData,
   TParams = {},
   TError = DefaultError,
 > {
-  useSuspenseQuery(
+  useSuspenseQuery<TData = TQueryFnData>(
     parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
     options?: Omit<
       UseSuspenseQueryOptions<
-        TData,
+        TQueryFnData,
         TError,
         TData,
         ServiceOperationQueryKey<TSchema, TParams>

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -286,7 +286,10 @@ describe('Qraft uses Suspense Query', () => {
       throw new Error('Promise should be resolved');
     }
 
-    expect(resultWithData.current.data).toEqual({
+    expect(
+      resultWithData.current
+        .data satisfies typeof qraft.approvalPolicies.getApprovalPoliciesId.types.data
+    ).toEqual({
       header: {
         'x-monite-version': '1.0.0',
       },

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -304,20 +304,20 @@ describe('Qraft uses Suspense Query', () => {
 });
 
 describe('Qraft uses Queries', () => {
-  it('supports useQueries with parameters and queryKey', async () => {
-    const parameters: typeof qraft.approvalPolicies.getApprovalPoliciesId.types.parameters =
-      {
-        header: {
-          'x-monite-version': '1.0.0',
-        },
-        path: {
-          approval_policy_id: '1',
-        },
-        query: {
-          items_order: ['asc', 'desc'],
-        },
-      };
+  const parameters: typeof qraft.approvalPolicies.getApprovalPoliciesId.types.parameters =
+    {
+      header: {
+        'x-monite-version': '1.0.0',
+      },
+      path: {
+        approval_policy_id: '1',
+      },
+      query: {
+        items_order: ['asc', 'desc'],
+      },
+    };
 
+  it('supports useQueries with parameters and queryKey', async () => {
     const { result } = renderHook(
       () =>
         qraft.approvalPolicies.getApprovalPoliciesId.useQueries({
@@ -341,6 +341,48 @@ describe('Qraft uses Queries', () => {
 
     await waitFor(() => {
       expect(result.current).toEqual([parameters, parameters]);
+    });
+  });
+
+  it('supports useQueries with unified parameters', async () => {
+    const { result } = renderHook(
+      () =>
+        qraft.approvalPolicies.getApprovalPoliciesId.useQueries({
+          queries: [{ parameters }, { parameters }],
+        }),
+      {
+        wrapper: Providers,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current[0]?.data?.path?.approval_policy_id).toEqual(
+        parameters.path.approval_policy_id
+      );
+      expect(result.current[1]?.data?.query?.items_order).toEqual(
+        parameters.query?.items_order
+      );
+    });
+  });
+
+  it('supports useQueries with unified parameters and combine(...)', async () => {
+    const { result } = renderHook(
+      () =>
+        qraft.approvalPolicies.getApprovalPoliciesId.useQueries({
+          queries: [{ parameters }, { parameters }],
+          combine: (results) =>
+            results.map((result) => result.data?.path?.approval_policy_id),
+        }),
+      {
+        wrapper: Providers,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current satisfies Array<string | undefined>).toEqual([
+        parameters.path.approval_policy_id,
+        parameters.path.approval_policy_id,
+      ]);
     });
   });
 });

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -57,7 +57,21 @@ describe('Qraft uses singular Query', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual({
+      expect(
+        result.current.data satisfies
+          | {
+              header?: {
+                'x-monite-version'?: string;
+              };
+              path?: {
+                approval_policy_id?: string;
+              };
+              query?: {
+                items_order?: ('asc' | 'desc')[];
+              };
+            }
+          | undefined
+      ).toEqual({
         header: {
           'x-monite-version': '1.0.0',
         },
@@ -97,6 +111,37 @@ describe('Qraft uses singular Query', () => {
 
     await waitFor(() => {
       expect(result.current.data).toEqual(getApprovalPoliciesIdQueryKey[1]);
+    });
+  });
+
+  it('supports useQuery with select()', async () => {
+    const { result } = renderHook(
+      () =>
+        qraft.approvalPolicies.getApprovalPoliciesId.useQuery(
+          {
+            header: {
+              'x-monite-version': '1.0.0',
+            },
+            path: {
+              approval_policy_id: '1',
+            },
+            query: {
+              items_order: ['asc', 'desc'],
+            },
+          },
+          {
+            select(data) {
+              return String(data.path?.approval_policy_id);
+            },
+          }
+        ),
+      {
+        wrapper: Providers,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data satisfies string | undefined).toEqual('1');
     });
   });
 

--- a/packages/rollup-config/package.json
+++ b/packages/rollup-config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "dev": "tsc -w",
+    "dev": "tsc --watch --noEmitOnError false",
     "lint": "echo 'No linting configured'",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "clean": "rimraf dist/"

--- a/packages/tanstack-query-react-plugin/package.json
+++ b/packages/tanstack-query-react-plugin/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "dev": "yarn build --watch",
+    "dev": "yarn build --watch --noEmitOnError false",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",


### PR DESCRIPTION
This PR addresses several typing-related issues in the `@openapi-graft/react`:

1. Fixed output type for:
   - `useQueries(...)`
   - `useSuspenseQueries(...)`

2. Improved typing for `select(...)` function in:
   - `useQuery(...)` and `useSuspenseQuery`
   - `useInfiniteQuery(...)` and `useSuspenseInfiniteQuery(...)`