### PR TITLE
feat: no arguments for `useQuery()` and `mutate()`

### DIFF
--- a/.changeset/fast-hornets-repeat.md
+++ b/.changeset/fast-hornets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': minor
+---
+
+Improve `userQuery()` to support calling without `{}` as the first argument if all parameters are optional or no parameters are required.

--- a/.changeset/giant-chairs-occur.md
+++ b/.changeset/giant-chairs-occur.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': minor
+---
+
+Improve `useMutation` to support calling `mutate()` or `mutateAsync()` without arguments if body or parameters are optional or `undefined`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,18 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@openapi-qraft/e2e": "1.0.0",
+    "@openapi-qraft/cli": "1.12.1",
+    "@openapi-qraft/eslint-config": "1.0.0",
+    "@openapi-qraft/openapi-typescript-plugin": "1.0.6",
+    "@openapi-qraft/plugin": "1.12.1",
+    "@openapi-qraft/react": "1.12.1",
+    "@openapi-qraft/rollup-config": "1.0.0",
+    "@openapi-qraft/tanstack-query-react-plugin": "1.12.1",
+    "@openapi-qraft/test-fixtures": "1.0.0",
+    "playground": "0.0.14",
+    "openapi-qraft-website": "0.0.0"
+  },
+  "changesets": []
+}

--- a/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
@@ -64,7 +64,8 @@ export interface paths {
         put?: never;
         /** Upload a files by ID */
         post: operations["post_files"];
-        delete?: never;
+        /** Delete all files */
+        delete: operations["delete_files"];
         options?: never;
         head?: never;
         patch?: never;
@@ -528,6 +529,41 @@ export interface operations {
                         body?: {
                             file?: string;
                             file_description?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorSchemaResponse"];
+                };
+            };
+        };
+    };
+    delete_files: {
+        parameters: {
+            query?: {
+                all?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        query?: {
+                            all?: boolean;
                         };
                     };
                 };

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
@@ -16,7 +16,8 @@ export interface paths {
         put?: never;
         /** Upload a files by ID */
         post: operations["post_files"];
-        delete?: never;
+        /** Delete all files */
+        delete: operations["delete_files"];
         options?: never;
         head?: never;
         patch?: never;
@@ -207,6 +208,41 @@ export interface operations {
                         body?: {
                             file?: string;
                             file_description?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorSchemaResponse"];
+                };
+            };
+        };
+    };
+    delete_files: {
+        parameters: {
+            query?: {
+                all?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        query?: {
+                            all?: boolean;
                         };
                     };
                 };

--- a/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
+++ b/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
@@ -344,6 +344,32 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "summary": "Upload a files by ID",
       },
       {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files",
+        "security": undefined,
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete all files",
+      },
+      {
         "deprecated": true,
         "description": undefined,
         "errors": {
@@ -737,6 +763,32 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           "200": "application/json",
         },
         "summary": "Upload a files by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files",
+        "security": undefined,
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete all files",
       },
       {
         "deprecated": true,
@@ -1134,6 +1186,32 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "summary": "Upload a files by ID",
       },
       {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files",
+        "security": undefined,
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete all files",
+      },
+      {
         "deprecated": true,
         "description": undefined,
         "errors": {
@@ -1264,6 +1342,32 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           "200": "application/json",
         },
         "summary": "Upload a files by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files",
+        "security": undefined,
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete all files",
       },
       {
         "deprecated": true,
@@ -1659,6 +1763,32 @@ exports[`getServices > matches snapshot with default options 1`] = `
           "200": "application/json",
         },
         "summary": "Upload a files by ID",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": "application/json",
+        },
+        "mediaType": undefined,
+        "method": "delete",
+        "name": "deleteFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files",
+        "security": undefined,
+        "success": {
+          "200": "application/json",
+        },
+        "summary": "Delete all files",
       },
       {
         "deprecated": true,

--- a/packages/react-client/src/lib/AreAllOptional.ts
+++ b/packages/react-client/src/lib/AreAllOptional.ts
@@ -1,0 +1,8 @@
+export type AreAllOptional<T> =
+  NonNullable<T> extends never
+    ? true
+    : {
+          [K in keyof T]-?: undefined extends T[K] ? never : K;
+        }[keyof T] extends never
+      ? true
+      : false;

--- a/packages/react-client/src/service-operation/ServiceOperationUseMutation.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseMutation.ts
@@ -4,6 +4,7 @@ import type {
   UseMutationResult,
 } from '@tanstack/react-query';
 
+import type { AreAllOptional } from '../lib/AreAllOptional.js';
 import type { ServiceOperationMutationKey } from './ServiceOperationKey.js';
 
 export interface ServiceOperationUseMutation<
@@ -22,25 +23,65 @@ export interface ServiceOperationUseMutation<
     TContext = unknown,
   >(
     parameters?: undefined,
-    options?: Omit<
-      UseMutationOptions<TData, TError, TVariables, TContext>,
-      'mutationKey'
-    > & {
-      mutationKey?: ServiceOperationMutationKey<TSchema, TParams>;
-    },
+    options?: ServiceOperationUseMutationOptions<
+      TSchema,
+      TData,
+      TParams,
+      TVariables,
+      TError,
+      TContext
+    >,
     queryClient?: QueryClient
   ): UseMutationResult<TData, TError | Error, TVariables, TContext>;
 
   useMutation<TVariables extends TBody, TContext = unknown>(
-    parameters: TParams,
-    options?: Omit<
-      UseMutationOptions<TData, TError, TVariables, TContext>,
-      'mutationKey'
+    parameters: AreAllOptional<TParams> extends true ? TParams | void : TParams,
+    options?: ServiceOperationUseMutationOptions<
+      TSchema,
+      TData,
+      TParams,
+      TVariables,
+      TError,
+      TContext
     >,
     queryClient?: QueryClient
-  ): UseMutationResult<TData, TError | Error, TVariables, TContext>;
+  ): UseMutationResult<
+    TData,
+    TError | Error,
+    AreAllOptional<TVariables> extends true ? TVariables | void : TVariables,
+    TContext
+  >;
 }
 
-export type MutationVariables<TBody, TParams> = {
-  body: TBody;
-} & (NonNullable<TParams> extends never ? {} : TParams);
+export type MutationVariables<TBody, TParams> =
+  NonNullable<TBody> extends never
+    ? NonNullable<TParams> extends never
+      ? void
+      : AreAllOptional<TParams> extends true
+        ? TParams | void
+        : TParams
+    : NonNullable<TParams> extends never
+      ? AreAllOptional<TBody> extends true
+        ? { body?: TBody } | void
+        : { body: TBody }
+      : AreAllOptional<TBody> extends true
+        ? AreAllOptional<TParams> extends true
+          ? ({ body?: TBody } & TParams) | void
+          : { body?: TBody } & TParams
+        : {
+            body: TBody;
+          } & TParams;
+
+type ServiceOperationUseMutationOptions<
+  TSchema extends { url: string; method: string },
+  TData,
+  TParams,
+  TVariables,
+  TError,
+  TContext = unknown,
+> = Omit<
+  UseMutationOptions<TData, TError, TVariables, TContext>,
+  'mutationKey'
+> & {
+  mutationKey?: ServiceOperationMutationKey<TSchema, TParams>;
+};

--- a/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
@@ -6,6 +6,7 @@ import type {
   UseQueryResult,
 } from '@tanstack/react-query';
 
+import { AreAllOptional } from '../lib/AreAllOptional.js';
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
 export interface ServiceOperationUseQuery<
@@ -19,7 +20,9 @@ export interface ServiceOperationUseQuery<
   ): ServiceOperationQueryKey<TSchema, QueryKeyParams>;
 
   useQuery<TData = TQueryFnData>(
-    parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
+    parameters:
+      | ServiceOperationQueryKey<TSchema, TParams>
+      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
     options?: Omit<
       UndefinedInitialDataOptions<
         TQueryFnData,
@@ -33,7 +36,9 @@ export interface ServiceOperationUseQuery<
   ): UseQueryResult<TData, TError | Error>;
 
   useQuery<TData = TQueryFnData>(
-    parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
+    parameters:
+      | ServiceOperationQueryKey<TSchema, TParams>
+      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
     options: Omit<
       DefinedInitialDataOptions<
         TQueryFnData,

--- a/packages/react-client/src/tests/msw/handlers.ts
+++ b/packages/react-client/src/tests/msw/handlers.ts
@@ -92,6 +92,20 @@ export const handlers = [
     }
   ),
 
+  http.delete<
+    ServicePathParameters<Services['files']['deleteFiles']>,
+    ServiceRequestBodyParameters<Services['files']['deleteFiles']>,
+    ServiceResponseParameters<Services['files']['deleteFiles']>
+  >(
+    openApiToMswPath(services.files.postFiles.schema.url),
+    async ({ request }) => {
+      const query = getQueryParameters<Services['files']['deleteFiles']>(
+        request.url
+      );
+      return HttpResponse.json({ query });
+    }
+  ),
+
   http.get<
     ServicePathParameters<Services['files']['getFiles']>,
     undefined,

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -217,12 +217,19 @@ describe('Qraft uses singular Query', () => {
   });
 
   it('supports useQuery with optional params', async () => {
-    const { result } = renderHook(() => qraft.files.getFileList.useQuery({}), {
-      wrapper: Providers,
-    });
+    const { result } = renderHook(
+      () => ({
+        queryNoArgsWithVoidParameters: qraft.files.getFileList.useQuery(),
+        queryWithEmptyParameters: qraft.files.getFileList.useQuery({}),
+      }),
+
+      {
+        wrapper: Providers,
+      }
+    );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual({
+      const data = {
         data: [
           {
             file_type: 'pdf',
@@ -243,7 +250,9 @@ describe('Qraft uses singular Query', () => {
             url: 'http://localhost:3000/3',
           },
         ],
-      });
+      };
+      expect(result.current.queryNoArgsWithVoidParameters.data).toEqual(data);
+      expect(result.current.queryWithEmptyParameters.data).toEqual(data);
     });
   });
 });
@@ -1875,7 +1884,7 @@ describe('Qraft uses utils', () => {
   it('throws an error when calling an unsupported service ', () => {
     expect(() =>
       // @ts-expect-error - Invalid usage
-      qraft.counterparts.postCounterpartsIdAddresses.useQuery()
+      qraft.counterparts.postCounterpartsIdAddresses.useQuery({})
     ).toThrowError(/Service operation not found/i);
   });
 

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -20,6 +20,11 @@ export interface FilesService {
         url: "/files";
         mediaType: "multipart/form-data";
     }, NonNullable<paths["/files"]["post"]["requestBody"]>["content"]["multipart/form-data"], paths["/files"]["post"]["responses"]["200"]["content"]["application/json"], undefined, paths["/files"]["post"]["responses"]["default"]["content"]["application/json"]>;
+    /** @summary Delete all files */
+    deleteFiles: ServiceOperationMutation<{
+        method: "delete";
+        url: "/files";
+    }, undefined, paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"], paths["/files"]["delete"]["parameters"], paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"]>;
     /**
      * @deprecated
      * @summary Get a file list
@@ -49,6 +54,12 @@ export const filesService: {
             mediaType: "multipart/form-data";
         };
     };
+    deleteFiles: {
+        schema: {
+            method: "delete";
+            url: "/files";
+        };
+    };
     getFileList: {
         schema: {
             method: "get";
@@ -71,6 +82,12 @@ export const filesService: {
             method: "post",
             url: "/files",
             mediaType: "multipart/form-data"
+        }
+    },
+    deleteFiles: {
+        schema: {
+            method: "delete",
+            url: "/files"
         }
     },
     getFileList: {

--- a/packages/test-fixtures/openapi.json
+++ b/packages/test-fixtures/openapi.json
@@ -564,6 +564,51 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": ["Files"],
+        "summary": "Delete all files",
+        "operationId": "delete_files",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "all",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "object",
+                      "properties": {
+                        "all": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          }
+        }
       }
     },
     "/files/list": {


### PR DESCRIPTION
This PR introduces improvements to both the `userQuery` and `useMutation` functions to enhance their flexibility and usability:

1. **Improvement to `userQuery`**:
   - `userQuery()` can now be called without `{}` as the first argument if all parameters are optional or no parameters are required.

2. **Improvement to `useMutation`**:
   - `useMutation` now supports calling `mutate()` or `mutateAsync()` without arguments if body or parameters are optional or `undefined`.

These changes aim to simplify the usage of these functions, making them more intuitive and reducing the need for unnecessary argument passing.