### PR TITLE
chore: remove concurrency and production environment from versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
-
 jobs:
   release:
     name: Changesets Versioning
@@ -14,7 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    environment: production
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Removed concurrency and production environment usage from the `versioning.yaml` workflow.