### PR TITLE
fix: simplify package version retrieval for enhanced Node.js compatibility

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "origin/main",
+  "baseBranch": "origin/versions/1.13.x",
   "updateInternalDependencies": "patch",
   "ignore": ["@openapi-qraft/e2e", "playground", "openapi-qraft-website"]
 }

--- a/.changeset/purple-kids-thank.md
+++ b/.changeset/purple-kids-thank.md
@@ -1,0 +1,6 @@
+---
+'@openapi-qraft/plugin': patch
+---
+
+Simplified the method for retrieving the package version by implementing a more straightforward approach. This change
+improves maintainability and ensures better compatibility across different Node.js versions (18, 20, and 22).

--- a/.changeset/purple-kids-thank.md
+++ b/.changeset/purple-kids-thank.md
@@ -1,6 +1,0 @@
----
-'@openapi-qraft/plugin': patch
----
-
-Simplified the method for retrieving the package version by implementing a more straightforward approach. This change
-improves maintainability and ensures better compatibility across different Node.js versions (18, 20, and 22).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - versions/1.13.x
 
 jobs:
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: yarn exec .changeset/publish.sh --create-git-tags
-          version: yarn exec .changeset/version.sh
+          version: exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openapi-qraft/cli
 
+## 1.13.1
+
+### Patch Changes
+
+- Updated dependencies [63ba3ff]
+  - @openapi-qraft/plugin@1.13.1
+  - @openapi-qraft/openapi-typescript-plugin@1.0.8
+  - @openapi-qraft/tanstack-query-react-plugin@1.13.1
+
 ## 1.13.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openapi-qraft/cli",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "CLI for generating typed Tanstack Query React Hooks and services from OpenAPI Schemas, improving type safety in React apps",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/openapi-typescript-plugin/CHANGELOG.md
+++ b/packages/openapi-typescript-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openapi-qraft/openapi-typescript
 
+## 1.0.8
+
+### Patch Changes
+
+- Updated dependencies [63ba3ff]
+  - @openapi-qraft/plugin@1.13.1
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/openapi-typescript-plugin/package.json
+++ b/packages/openapi-typescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openapi-qraft/openapi-typescript-plugin",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/plugin/.gitignore
+++ b/packages/plugin/.gitignore
@@ -1,0 +1,1 @@
+/src/packageVersion.ts

--- a/packages/plugin/CHANGELOG.md
+++ b/packages/plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openapi-qraft/plugin
 
+## 1.13.1
+
+### Patch Changes
+
+- 63ba3ff: Simplified the method for retrieving the package version by implementing a more straightforward approach. This change
+  improves maintainability and ensures better compatibility across different Node.js versions (18, 20, and 22).
+
 ## 1.13.0
 
 ### Patch Changes

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openapi-qraft/plugin",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "packageManager": "yarn@4.0.2",
   "type": "module",
   "scripts": {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
-    "clean": "rimraf dist/"
+    "clean": "rimraf dist/",
+    "write-package-version-file": "yarn exec ../../write-package-version-file.sh"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/plugin/src/lib/QraftCommand.ts
+++ b/packages/plugin/src/lib/QraftCommand.ts
@@ -1,12 +1,12 @@
 import type { Option } from 'commander';
 import type { Service } from './open-api/getServices.js';
-import * as console from 'node:console';
 import { sep } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL, URL } from 'node:url';
 import c from 'ansi-colors';
 import { Command } from 'commander';
 import ora, { Ora } from 'ora';
+import { packageVersion } from '../packageVersion.js';
 import { parsePathGlobs } from './createServicePathMatch.js';
 import { filterDocumentPaths } from './filterDocumentPaths.js';
 import { GeneratorFile } from './GeneratorFile.js';
@@ -73,13 +73,6 @@ export class QraftCommand extends Command {
   }
 
   async actionCallback(...actionArgs: any[]) {
-    const { version: packageVersion } = await import(
-      '@openapi-qraft/plugin/package.json',
-      {
-        with: { type: 'json' },
-      }
-    ).then(({ default: packageJSON }) => packageJSON);
-
     const inputs = actionArgs.filter(
       (arg) => typeof arg === 'string'
     ) as string[];

--- a/packages/react-client/CHANGELOG.md
+++ b/packages/react-client/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openapi-qraft/react
 
+## 1.13.1
+
 ## 1.13.0
 
 ### Minor Changes

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openapi-qraft/react",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "API client for React, providing type-safe requests and dynamic Tanstack Query React Hooks via a modular, Proxy-based architecture.",
   "scripts": {
     "build": "NODE_ENV=production rollup --config rollup.config.mjs && tsc --project tsconfig.build.json --emitDeclarationOnly",

--- a/packages/tanstack-query-react-plugin/CHANGELOG.md
+++ b/packages/tanstack-query-react-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openapi-qraft/tanstack-query-react-plugin
 
+## 1.13.1
+
+### Patch Changes
+
+- Updated dependencies [63ba3ff]
+  - @openapi-qraft/plugin@1.13.1
+
 ## 1.13.0
 
 ### Patch Changes

--- a/packages/tanstack-query-react-plugin/package.json
+++ b/packages/tanstack-query-react-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openapi-qraft/tanstack-query-react-plugin",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/turbo.json
+++ b/turbo.json
@@ -3,32 +3,26 @@
   "tasks": {
     "build": {
       "cache": true,
-      "dependsOn": ["codegen", "^build"],
+      "dependsOn": ["write-package-version-file", "codegen", "^build"],
       "outputs": ["dist/**"]
     },
     "test": {
       "cache": true,
-      "dependsOn": ["^build"],
+      "dependsOn": ["write-package-version-file", "^build"],
       "outputs": ["coverage/**"]
     },
     "typecheck": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["write-package-version-file", "^build"]
     },
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["write-package-version-file", "^build"]
     },
     "lint": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["write-package-version-file", "^build"]
     },
     "clean": {
       "cache": false
@@ -41,6 +35,11 @@
         "src/api/**/*.ts"
       ],
       "inputs": []
+    },
+    "write-package-version-file": {
+      "cache": true,
+      "outputs": ["src/packageVersion.ts"],
+      "inputs": ["package.json"]
     }
   }
 }

--- a/write-package-version-file.sh
+++ b/write-package-version-file.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Creates a file with the package version
+# Package version is read from `package.json` and written to `src/packageVersion.ts`
+# relative to the package. `packageVersion.ts` could be used to retrieve the package version
+# without need to read `package.json` and include it in the build output.
+# Usage example (run from the root of the monorepo):
+# ```bash
+# (cd packages/sdk-api && yarn exec ../../write-package-version-file.sh)
+# ```
+
+if [ ! -f ./package.json ]; then
+  echo "package.json not found" >&2
+  exit 1
+fi
+
+PACKAGE_VERSION=$(node -p 'require("./package.json").version')
+OUTPUT_FILE="./src/packageVersion.ts"
+
+# Write package version to file
+echo "// This file was generated automatically" > "$OUTPUT_FILE"
+echo "export const packageVersion = '$PACKAGE_VERSION';" >> "$OUTPUT_FILE"


### PR DESCRIPTION
Simplified the method for retrieving the package version by transitioning to a more straightforward approach. Instead of dynamically importing or reading directly from `package.json`, the version is now generated in advance and stored in a dedicated file. This change improves maintainability and ensures better compatibility across different Node.js versions, specifically 18, 20, and 22.