### PR TITLE
feat: add Node.js 18.18.0 compatibility

### DIFF
--- a/.changeset/rare-bats-rest.md
+++ b/.changeset/rare-bats-rest.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/plugin": patch
+---
+
+Added compatibility with Node.js v18.18.0

--- a/packages/plugin/src/lib/parseOperationGlobs.ts
+++ b/packages/plugin/src/lib/parseOperationGlobs.ts
@@ -20,8 +20,9 @@ export const parseOperationGlobs = (operationFullGlobs: string) => {
   const methods = methodsGlobsRaw
     .split(',')
     .map((method) => method.trim().toLowerCase())
-    .filter(isSupportedOperationMethod)
-    .toSorted(sortSupportedMethods);
+    .filter(isSupportedOperationMethod);
+
+  methods.sort(sortSupportedMethods);
 
   return {
     methods: methods.length ? methods : undefined,


### PR DESCRIPTION
In this update, the `sort()` method has been used instead of `toSorted()`. The decision to use `sort()` ensures broader compatibility across different Node.js environments.