### PR TITLE
chore: fix changelog

### DIFF
--- a/packages/plugin/CHANGELOG.md
+++ b/packages/plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 77f0812: Added support for the `--operation-predefined-parameters` option to allow changing operation names.
+- 77f0812: Added support for the `--operation-name-modifier` option to allow changing operation names.
 - 346a408: Added multiple patterns support to `--filter-services <patterns...>` option.
 - 787f568: Updated `openapi-typescript` to `^7.3.0`.
 
@@ -36,7 +36,7 @@
 
 ### Minor Changes
 
-- 77f0812: Added support for the `--operation-predefined-parameters` option to allow changing operation names.
+- 77f0812: Added support for the `--operation-name-modifier` option to allow changing operation names.
 - 787f568: Updated `openapi-typescript` to `^7.3.0`.
 
 ## 1.13.1


### PR DESCRIPTION
Fixes a typo in the changelog where `--operation-predefined-parameters` was incorrectly listed. It has been corrected to `--operation-name-modifier`. The changes ensure that the documentation accurately reflects the available options for modifying operation names.