### PR TITLE
feat(react-client): filter output types depending on passed callbacks

### DIFF
--- a/.changeset/lucky-cobras-melt.md
+++ b/.changeset/lucky-cobras-melt.md
@@ -1,0 +1,6 @@
+---
+"@openapi-qraft/tanstack-query-react-plugin": minor
+"@openapi-qraft/react": minor
+---
+
+Updated the `qraftAPIClient(...)` to return only the set of services corresponding to the methods for which callbacks were passed.

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -69,6 +69,8 @@ TQuery
 treeshake
 TResult
 TSchema
+TCallbacks
+TServices
 tseslint
 TSignal
 TVariables

--- a/packages/react-client/src/callbacks/cancelQueries.ts
+++ b/packages/react-client/src/callbacks/cancelQueries.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationCancelQueries } from '../service-operation/ServiceOperationCancelQueries.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function cancelQueries<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationCancelQueries<

--- a/packages/react-client/src/callbacks/fetchInfiniteQuery.ts
+++ b/packages/react-client/src/callbacks/fetchInfiniteQuery.ts
@@ -1,13 +1,13 @@
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationFetchInfiniteQuery } from '../service-operation/ServiceOperationFetchInfiniteQuery.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientFetchMethod.js';
-import { ServiceOperationFetchInfiniteQuery } from '../service-operation/ServiceOperationFetchInfiniteQuery.js';
 
 export const fetchInfiniteQuery: <
   TSchema extends { url: string; method: 'get' | 'head' | 'options' },
   TData,
   TParams,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: TSchema,
   args: Parameters<
     ServiceOperationFetchInfiniteQuery<

--- a/packages/react-client/src/callbacks/fetchQuery.ts
+++ b/packages/react-client/src/callbacks/fetchQuery.ts
@@ -1,13 +1,13 @@
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationFetchQuery } from '../service-operation/ServiceOperationFetchQuery.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientFetchMethod.js';
-import { ServiceOperationFetchQuery } from '../service-operation/ServiceOperationFetchQuery.js';
 
 export const fetchQuery: <
   TSchema extends { url: string; method: 'get' | 'head' | 'options' },
   TData,
   TParams,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: TSchema,
   args: Parameters<
     ServiceOperationFetchQuery<TSchema, TData, TParams>['fetchQuery']

--- a/packages/react-client/src/callbacks/getInfiniteQueryData.ts
+++ b/packages/react-client/src/callbacks/getInfiniteQueryData.ts
@@ -1,11 +1,11 @@
 import type { InfiniteData } from '@tanstack/query-core';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientMethodWithQueryKey.js';
 
 export function getInfiniteQueryData<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<

--- a/packages/react-client/src/callbacks/getInfiniteQueryKey.ts
+++ b/packages/react-client/src/callbacks/getInfiniteQueryKey.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
 import { composeInfiniteQueryKey } from '../lib/composeInfiniteQueryKey.js';
+import { CreateAPIBasicClientOptions } from '../qraftAPIClient.js';
 import { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 
 export const getInfiniteQueryKey = (
-  qraftOptions: QraftClientOptions | undefined,
+  _qraftOptions: CreateAPIBasicClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<

--- a/packages/react-client/src/callbacks/getInfiniteQueryState.ts
+++ b/packages/react-client/src/callbacks/getInfiniteQueryState.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientMethodWithQueryKey.js';
 
 export function getInfiniteQueryState<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<

--- a/packages/react-client/src/callbacks/getMutationKey.ts
+++ b/packages/react-client/src/callbacks/getMutationKey.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIBasicClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationMutation } from '../service-operation/ServiceOperation.js';
 import { composeMutationKey } from '../lib/composeMutationKey.js';
-import { ServiceOperationMutation } from '../service-operation/ServiceOperation.js';
 
 export const getMutationKey = (
-  qraftOptions: QraftClientOptions | undefined,
+  _qraftOptions: CreateAPIBasicClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationMutation<

--- a/packages/react-client/src/callbacks/getQueriesData.ts
+++ b/packages/react-client/src/callbacks/getQueriesData.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
-import { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 
 export function getQueriesData<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, TData>['getQueriesData']

--- a/packages/react-client/src/callbacks/getQueryData.ts
+++ b/packages/react-client/src/callbacks/getQueryData.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientMethodWithQueryKey.js';
 
 export function getQueryData<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, TData>['getQueryData']

--- a/packages/react-client/src/callbacks/getQueryKey.ts
+++ b/packages/react-client/src/callbacks/getQueryKey.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIBasicClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { composeQueryKey } from '../lib/composeQueryKey.js';
-import { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 
 export const getQueryKey = (
-  qraftOptions: QraftClientOptions | undefined,
+  _qraftOptions: CreateAPIBasicClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, unknown>['getQueryKey']

--- a/packages/react-client/src/callbacks/getQueryState.ts
+++ b/packages/react-client/src/callbacks/getQueryState.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientMethodWithQueryKey.js';
 
 export function getQueryState<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, TData>['getQueryState']

--- a/packages/react-client/src/callbacks/invalidateQueries.ts
+++ b/packages/react-client/src/callbacks/invalidateQueries.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationInvalidateQueries } from '../service-operation/ServiceOperationInvalidateQueries.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function invalidateQueries<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationInvalidateQueries<

--- a/packages/react-client/src/callbacks/isFetching.ts
+++ b/packages/react-client/src/callbacks/isFetching.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationIsFetchingQueries } from '../service-operation/ServiceOperationIsFetchingQueries.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function isFetching<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationIsFetchingQueries<

--- a/packages/react-client/src/callbacks/isMutating.ts
+++ b/packages/react-client/src/callbacks/isMutating.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationIsMutatingQueries } from '../service-operation/ServiceOperationIsMutatingQueries.js';
 import { callQueryClientMethodWithMutationFilters } from '../lib/callQueryClientMethodWithMutationFilters.js';
 
 export function isMutating<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationIsMutatingQueries<

--- a/packages/react-client/src/callbacks/operationInvokeFn.ts
+++ b/packages/react-client/src/callbacks/operationInvokeFn.ts
@@ -1,7 +1,7 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
-import { ServiceOperationMutationFn } from '../service-operation/ServiceOperationMutationFn.js';
-import { ServiceOperationQueryFn } from '../service-operation/ServiceOperationQueryFn.js';
+import type { CreateAPIBasicClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationMutationFn } from '../service-operation/ServiceOperationMutationFn.js';
+import type { ServiceOperationQueryFn } from '../service-operation/ServiceOperationQueryFn.js';
 
 /**
  * Called when <service>.<operation>(...) is invoked.
@@ -12,7 +12,7 @@ export const operationInvokeFn: <
   TData,
   TParams,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIBasicClientOptions,
   schema: TSchema,
   args:
     | Parameters<ServiceOperationQueryFn<TSchema, TData, TParams>>

--- a/packages/react-client/src/callbacks/prefetchInfiniteQuery.ts
+++ b/packages/react-client/src/callbacks/prefetchInfiniteQuery.ts
@@ -1,13 +1,13 @@
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationFetchInfiniteQuery } from '../service-operation/ServiceOperationFetchInfiniteQuery.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientFetchMethod.js';
-import { ServiceOperationFetchInfiniteQuery } from '../service-operation/ServiceOperationFetchInfiniteQuery.js';
 
 export const prefetchInfiniteQuery: <
   TSchema extends { url: string; method: 'get' | 'head' | 'options' },
   TData,
   TParams,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: TSchema,
   args: Parameters<
     ServiceOperationFetchInfiniteQuery<

--- a/packages/react-client/src/callbacks/prefetchQuery.ts
+++ b/packages/react-client/src/callbacks/prefetchQuery.ts
@@ -1,13 +1,13 @@
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
+import type { ServiceOperationFetchQuery } from '../service-operation/ServiceOperationFetchQuery.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientFetchMethod.js';
-import { ServiceOperationFetchQuery } from '../service-operation/ServiceOperationFetchQuery.js';
 
 export const prefetchQuery: <
   TSchema extends { url: string; method: 'get' | 'head' | 'options' },
   TData,
   TParams,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: TSchema,
   args: Parameters<
     ServiceOperationFetchQuery<TSchema, TData, TParams>['prefetchQuery']

--- a/packages/react-client/src/callbacks/refetchQueries.ts
+++ b/packages/react-client/src/callbacks/refetchQueries.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationRefetchQueries } from '../service-operation/ServiceOperationRefetchQueries.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function refetchQueries<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationRefetchQueries<

--- a/packages/react-client/src/callbacks/removeQueries.ts
+++ b/packages/react-client/src/callbacks/removeQueries.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationRemoveQueries } from '../service-operation/ServiceOperationRemoveQueries.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function removeQueries<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationRemoveQueries<

--- a/packages/react-client/src/callbacks/resetQueries.ts
+++ b/packages/react-client/src/callbacks/resetQueries.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationResetQueries } from '../service-operation/ServiceOperationResetQueries.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function resetQueries<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationResetQueries<

--- a/packages/react-client/src/callbacks/setInfiniteQueryData.ts
+++ b/packages/react-client/src/callbacks/setInfiniteQueryData.ts
@@ -1,11 +1,11 @@
+import type { InfiniteData } from '@tanstack/query-core';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationSetInfiniteQueryData } from '../service-operation/ServiceOperationSetInfiniteQueryData.js';
-import { InfiniteData } from '@tanstack/query-core';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientMethodWithQueryKey.js';
 
 export function setInfiniteQueryData<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationSetInfiniteQueryData<

--- a/packages/react-client/src/callbacks/setQueriesData.ts
+++ b/packages/react-client/src/callbacks/setQueriesData.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationSetQueriesData } from '../service-operation/ServiceOperationSetQueriesData.js';
 import { callQueryClientMethodWithQueryFilters } from '../lib/callQueryClientMethodWithQueryFilters.js';
 
 export function setQueriesData<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationSetQueriesData<

--- a/packages/react-client/src/callbacks/setQueryData.ts
+++ b/packages/react-client/src/callbacks/setQueryData.ts
@@ -1,10 +1,10 @@
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationSetQueryData } from '../service-operation/ServiceOperationSetQueryData.js';
 import { callQueryClientMethodWithQueryKey } from '../lib/callQueryClientMethodWithQueryKey.js';
 
 export function setQueryData<TData>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationSetQueryData<

--- a/packages/react-client/src/callbacks/useInfiniteQuery.ts
+++ b/packages/react-client/src/callbacks/useInfiniteQuery.ts
@@ -3,7 +3,7 @@
 import type { DefaultError, InfiniteData } from '@tanstack/query-core';
 import type { UseInfiniteQueryResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useInfiniteQuery as useInfiniteQueryBase } from '@tanstack/react-query';
 import { useComposeUseQueryOptions } from '../lib/useComposeUseQueryOptions.js';
@@ -13,7 +13,7 @@ export const useInfiniteQuery: <
   TError = DefaultError,
   TData = InfiniteData<TQueryFnData>,
 >(
-  qraftOptions: QraftClientOptions | undefined,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, unknown>['useInfiniteQuery']

--- a/packages/react-client/src/callbacks/useIsFetching.ts
+++ b/packages/react-client/src/callbacks/useIsFetching.ts
@@ -1,13 +1,13 @@
 'use client';
 
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useIsFetching as useIsFetchingTanstack } from '@tanstack/react-query';
 import { composeQueryFilters } from '../lib/composeQueryFilters.js';
 
 export const useIsFetching: <TVariables = unknown>(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<

--- a/packages/react-client/src/callbacks/useIsMutating.ts
+++ b/packages/react-client/src/callbacks/useIsMutating.ts
@@ -3,7 +3,7 @@
 import type { DefaultError } from '@tanstack/query-core';
 import type { UseMutationResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationMutation } from '../service-operation/ServiceOperation.js';
 import { useIsMutating as useIsMutatingStateTanstack } from '@tanstack/react-query';
 import { composeMutationFilters } from '../lib/composeMutationFilters.js';
@@ -14,7 +14,7 @@ export const useIsMutating: <
   TVariables = unknown,
   TContext = unknown,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationMutation<

--- a/packages/react-client/src/callbacks/useMutation.ts
+++ b/packages/react-client/src/callbacks/useMutation.ts
@@ -3,7 +3,7 @@
 import type { DefaultError } from '@tanstack/query-core';
 import type { UseMutationResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationMutation } from '../service-operation/ServiceOperation.js';
 import type { ServiceOperationMutationKey } from '../service-operation/ServiceOperationKey.js';
 import { useMutation as useMutationBase } from '@tanstack/react-query';
@@ -15,7 +15,7 @@ export const useMutation: <
   TVariables = void,
   TContext = unknown,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationMutation<

--- a/packages/react-client/src/callbacks/useMutationState.ts
+++ b/packages/react-client/src/callbacks/useMutationState.ts
@@ -1,13 +1,11 @@
 'use client';
 
 import type { DefaultError } from '@tanstack/query-core';
+import type { UseMutationResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationMutation } from '../service-operation/ServiceOperation.js';
-import {
-  UseMutationResult,
-  useMutationState as useMutationStateTanstack,
-} from '@tanstack/react-query';
+import { useMutationState as useMutationStateTanstack } from '@tanstack/react-query';
 import { composeMutationFilters } from '../lib/composeMutationFilters.js';
 
 export const useMutationState: <
@@ -16,7 +14,7 @@ export const useMutationState: <
   TVariables = unknown,
   TContext = unknown,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationMutation<

--- a/packages/react-client/src/callbacks/useQueries.ts
+++ b/packages/react-client/src/callbacks/useQueries.ts
@@ -2,13 +2,13 @@
 
 import type { QueriesResults } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useQueries as useQueriesTanstack } from '@tanstack/react-query';
 import { composeQueryKey } from '../lib/composeQueryKey.js';
 
 export const useQueries: (
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, unknown>['useQueries']

--- a/packages/react-client/src/callbacks/useQuery.ts
+++ b/packages/react-client/src/callbacks/useQuery.ts
@@ -3,13 +3,13 @@
 import type { DefaultError } from '@tanstack/query-core';
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useQuery as useQueryTanstack } from '@tanstack/react-query';
 import { useComposeUseQueryOptions } from '../lib/useComposeUseQueryOptions.js';
 
 export const useQuery: <TData = unknown, TError = DefaultError>(
-  qraftOptions: QraftClientOptions | undefined,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, unknown>['useQuery']

--- a/packages/react-client/src/callbacks/useSuspenseInfiniteQuery.ts
+++ b/packages/react-client/src/callbacks/useSuspenseInfiniteQuery.ts
@@ -3,7 +3,7 @@
 import type { DefaultError, InfiniteData } from '@tanstack/query-core';
 import type { UseSuspenseInfiniteQueryResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useSuspenseInfiniteQuery as useSuspenseInfiniteQueryTanstack } from '@tanstack/react-query';
 import { useComposeUseQueryOptions } from '../lib/useComposeUseQueryOptions.js';
@@ -13,7 +13,7 @@ export const useSuspenseInfiniteQuery: <
   TError = DefaultError,
   TData = InfiniteData<TQueryFnData>,
 >(
-  qraftOptions: QraftClientOptions | undefined,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<

--- a/packages/react-client/src/callbacks/useSuspenseQueries.ts
+++ b/packages/react-client/src/callbacks/useSuspenseQueries.ts
@@ -2,13 +2,13 @@
 
 import type { SuspenseQueriesResults } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useSuspenseQueries as useSuspenseQueriesTanstack } from '@tanstack/react-query';
 import { composeQueryKey } from '../lib/composeQueryKey.js';
 
 export const useSuspenseQueries: (
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<

--- a/packages/react-client/src/callbacks/useSuspenseQuery.ts
+++ b/packages/react-client/src/callbacks/useSuspenseQuery.ts
@@ -3,7 +3,7 @@
 import type { DefaultError } from '@tanstack/query-core';
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { OperationSchema } from '../lib/requestFn.js';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQuery } from '../service-operation/ServiceOperation.js';
 import { useSuspenseQuery as useSuspenseQueryTanstack } from '@tanstack/react-query';
 import { useComposeUseQueryOptions } from '../lib/useComposeUseQueryOptions.js';
@@ -13,7 +13,7 @@ export const useSuspenseQuery: <
   TError = DefaultError,
   TData = TQueryFnData,
 >(
-  qraftOptions: QraftClientOptions | undefined,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: Parameters<
     ServiceOperationQuery<OperationSchema, unknown, unknown>['useSuspenseQuery']

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -1,4 +1,12 @@
-export { qraftAPIClient, type QraftClientOptions } from './qraftAPIClient.js';
+export {
+  qraftAPIClient,
+  type CreateAPIClientOptions,
+  type CreateAPIBasicClientOptions,
+  type CreateAPIQueryClientOptions,
+  type APIQueryClientServices,
+  type APIBasicClientServices,
+  type QraftClientOptions,
+} from './qraftAPIClient.js';
 export {
   requestFn,
   baseRequestFn,

--- a/packages/react-client/src/lib/callQueryClientFetchMethod.ts
+++ b/packages/react-client/src/lib/callQueryClientFetchMethod.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from '@tanstack/query-core';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema, RequestFn } from './requestFn.js';
 import { composeInfiniteQueryKey } from './composeInfiniteQueryKey.js';
 import { composeQueryKey } from './composeQueryKey.js';
@@ -12,7 +12,7 @@ import { shelfMerge } from './shelfMerge.js';
 export function callQueryClientMethodWithQueryKey<
   QFMethod extends QueryKeyMethods,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   queryFilterMethod: QFMethod,
   schema: OperationSchema,
   infinite: boolean,

--- a/packages/react-client/src/lib/callQueryClientMethodWithMutationFilters.ts
+++ b/packages/react-client/src/lib/callQueryClientMethodWithMutationFilters.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from '@tanstack/query-core';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema } from './requestFn.js';
-import { QraftClientOptions } from '@openapi-qraft/react';
 import { composeMutationFilters } from './composeMutationFilters.js';
 
 /**
@@ -10,7 +10,7 @@ import { composeMutationFilters } from './composeMutationFilters.js';
 export function callQueryClientMethodWithMutationFilters<
   QFMethod extends QueryFilterMethods,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   queryFilterMethod: QFMethod,
   schema: OperationSchema,
   args: [...Parameters<(typeof QueryClient.prototype)[QFMethod]>, QueryClient]

--- a/packages/react-client/src/lib/callQueryClientMethodWithQueryFilters.ts
+++ b/packages/react-client/src/lib/callQueryClientMethodWithQueryFilters.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from '@tanstack/query-core';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema } from './requestFn.js';
 import { composeQueryFilters } from './composeQueryFilters.js';
 
@@ -10,7 +10,7 @@ import { composeQueryFilters } from './composeQueryFilters.js';
 export function callQueryClientMethodWithQueryFilters<
   QFMethod extends QueryFilterMethods,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   queryFilterMethod: QFMethod,
   schema: OperationSchema,
   args: [...Parameters<(typeof QueryClient.prototype)[QFMethod]>, QueryClient]

--- a/packages/react-client/src/lib/callQueryClientMethodWithQueryKey.ts
+++ b/packages/react-client/src/lib/callQueryClientMethodWithQueryKey.ts
@@ -1,6 +1,6 @@
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { QueryClient } from '@tanstack/query-core';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema } from './requestFn.js';
-import { QueryClient } from '@tanstack/query-core';
 import { composeInfiniteQueryKey } from './composeInfiniteQueryKey.js';
 import { composeQueryKey } from './composeQueryKey.js';
 
@@ -11,7 +11,7 @@ import { composeQueryKey } from './composeQueryKey.js';
 export function callQueryClientMethodWithQueryKey<
   QFMethod extends QueryKeyMethods,
 >(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   queryClientMethod: QFMethod,
   schema: OperationSchema,
   infinite: boolean,

--- a/packages/react-client/src/lib/requestFn.ts
+++ b/packages/react-client/src/lib/requestFn.ts
@@ -16,6 +16,8 @@ export async function requestFn<T>(
   requestInfo: RequestFnInfo,
   options?: RequestFnOptions
 ): Promise<T> {
+  // todo::refactor according to https://github.com/openapi-ts/openapi-typescript/blob/2a4b067f43f7e0b75aecbf5c2fb3013a4e96e591/packages/openapi-fetch/src/index.js#L158-L178
+  // todo::return full response and error, not throw! add invoke method typed errors
   return baseRequestFn(schema, requestInfo, {
     urlSerializer,
     bodySerializer,

--- a/packages/react-client/src/lib/useComposeUseQueryOptions.ts
+++ b/packages/react-client/src/lib/useComposeUseQueryOptions.ts
@@ -2,7 +2,7 @@
 
 import type { QueryClient } from '@tanstack/query-core';
 import type { UseQueryOptions } from '@tanstack/react-query';
-import type { QraftClientOptions } from '../qraftAPIClient.js';
+import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { ServiceOperationQueryKey } from '../service-operation/ServiceOperationKey.js';
 import type { OperationSchema } from './requestFn.js';
 import { composeInfiniteQueryKey } from './composeInfiniteQueryKey.js';
@@ -14,7 +14,7 @@ import { shelfMerge } from './shelfMerge.js';
  * @internal
  */
 export function useComposeUseQueryOptions(
-  qraftOptions: QraftClientOptions,
+  qraftOptions: CreateAPIQueryClientOptions,
   schema: OperationSchema,
   args: UseQueryOptionsArgs,
   infinite: boolean

--- a/packages/react-client/src/service-operation/ServiceOperationUseMutation.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseMutation.ts
@@ -13,8 +13,8 @@ export interface ServiceOperationUseMutation<
   TParams,
   TError = DefaultError,
 > {
-  getMutationKey<TMutationKeyParams extends TParams | undefined = undefined>(
-    parameters?: TMutationKeyParams
+  getMutationKey<TMutationKeyParams extends TParams>(
+    parameters: TMutationKeyParams | void
   ): ServiceOperationMutationKey<TSchema, TMutationKeyParams>;
 
   useMutation<

--- a/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
@@ -11,11 +11,11 @@ import { AreAllOptional } from '../lib/AreAllOptional.js';
 export interface ServiceOperationUseQuery<
   TSchema extends { url: string; method: string },
   TQueryFnData,
-  TParams = {},
+  TParams,
   TError = DefaultError,
 > {
-  getQueryKey<QueryKeyParams extends TParams | undefined = undefined>(
-    parameters?: QueryKeyParams
+  getQueryKey<QueryKeyParams extends TParams>(
+    parameters: QueryKeyParams | void
   ): ServiceOperationQueryKey<TSchema, QueryKeyParams>;
 
   useQuery<TData = TQueryFnData>(

--- a/packages/react-client/src/tests/QraftSecureRequestFn.test.tsx
+++ b/packages/react-client/src/tests/QraftSecureRequestFn.test.tsx
@@ -1,10 +1,10 @@
+import type { CreateAPIBasicClientOptions } from '../qraftAPIClient.js';
 import type { Services } from './fixtures/api/index.js';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 import { vi } from 'vitest';
 import { requestFn } from '../lib/requestFn.js';
-import { type QraftClientOptions } from '../qraftAPIClient.js';
 import { QraftSecureRequestFn } from '../Unstable_QraftSecureRequestFn.js';
 import { createTestJwt } from './createTestJwt.js';
 import { createAPIClient } from './fixtures/api/index.js';
@@ -342,7 +342,7 @@ function Providers({
   requestFn: requestFnProp,
 }: {
   children: ReactNode;
-  requestFn: QraftClientOptions['requestFn'];
+  requestFn: CreateAPIBasicClientOptions['requestFn'];
 }) {
   const { qraft, queryClient } = useMemo(() => {
     const queryClient = new QueryClient();

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/create-api-client.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/create-api-client.ts.snapshot.ts
@@ -3,9 +3,12 @@
  * Do not make direct changes to the file.
  */
 
-import { qraftAPIClient, QraftClientOptions } from "@openapi-qraft/react";
+import { qraftAPIClient, type APIBasicClientServices, type CreateAPIBasicClientOptions, type CreateAPIClientOptions, type CreateAPIQueryClientOptions } from "@openapi-qraft/react";
 import * as callbacks from "@openapi-qraft/react/callbacks/index";
-import { services, Services } from "./services/index.js";
-export function createAPIClient(options: QraftClientOptions): Services {
-    return qraftAPIClient<Services, typeof callbacks>(services, callbacks, options);
+import { services, type Services } from "./services/index.js";
+export function createAPIClient(options: CreateAPIQueryClientOptions): Services;
+export function createAPIClient(options: CreateAPIBasicClientOptions): APIBasicClientServices<Services, Callbacks>;
+export function createAPIClient(options: CreateAPIClientOptions): Services | APIBasicClientServices<Services, Callbacks> {
+    return qraftAPIClient<Services, Callbacks>(services, callbacks, options);
 }
+type Callbacks = typeof callbacks;

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getClientFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getClientFactory.ts
@@ -8,7 +8,7 @@ type Options = {
 export const getClientFactory = (options: Options) => {
   return [
     ...getClientImportsFactory(options),
-    getCreateClientFunctionFactory(),
+    ...getCreateClientFunctionFactory(),
   ];
 };
 
@@ -30,10 +30,17 @@ const getClientImportsFactory = ({
             undefined,
             factory.createIdentifier('qraftAPIClient')
           ),
-          factory.createImportSpecifier(
-            false,
-            undefined,
-            factory.createIdentifier('QraftClientOptions')
+          ...[
+            'APIBasicClientServices',
+            'CreateAPIBasicClientOptions',
+            'CreateAPIClientOptions',
+            'CreateAPIQueryClientOptions',
+          ].map((name) =>
+            factory.createImportSpecifier(
+              true,
+              undefined,
+              factory.createIdentifier(name)
+            )
           ),
         ])
       ),
@@ -62,7 +69,7 @@ const getClientImportsFactory = ({
             factory.createIdentifier('services')
           ),
           factory.createImportSpecifier(
-            false,
+            true,
             undefined,
             factory.createIdentifier('Services')
           ),
@@ -79,52 +86,135 @@ const getClientImportsFactory = ({
 const getCreateClientFunctionFactory = () => {
   const factory = ts.factory;
 
-  return factory.createFunctionDeclaration(
-    [factory.createToken(ts.SyntaxKind.ExportKeyword)],
-    undefined,
-    factory.createIdentifier('createAPIClient'),
-    undefined,
-    [
-      factory.createParameterDeclaration(
-        undefined,
-        undefined,
-        factory.createIdentifier('options'),
-        undefined,
-        factory.createTypeReferenceNode(
-          factory.createIdentifier('QraftClientOptions'),
+  return [
+    factory.createFunctionDeclaration(
+      [factory.createToken(ts.SyntaxKind.ExportKeyword)],
+      undefined,
+      factory.createIdentifier('createAPIClient'),
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          factory.createIdentifier('options'),
+          undefined,
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('CreateAPIQueryClientOptions'),
+            undefined
+          ),
           undefined
         ),
+      ],
+      factory.createTypeReferenceNode(
+        factory.createIdentifier('Services'),
         undefined
       ),
-    ],
-    factory.createTypeReferenceNode(
-      factory.createIdentifier('Services'),
       undefined
     ),
-    factory.createBlock(
+    factory.createFunctionDeclaration(
+      [factory.createToken(ts.SyntaxKind.ExportKeyword)],
+      undefined,
+      factory.createIdentifier('createAPIClient'),
+      undefined,
       [
-        factory.createReturnStatement(
-          factory.createCallExpression(
-            factory.createIdentifier('qraftAPIClient'),
-            [
-              factory.createTypeReferenceNode(
-                factory.createIdentifier('Services'),
-                undefined
-              ),
-              factory.createTypeQueryNode(
-                factory.createIdentifier('callbacks'),
-                undefined
-              ),
-            ],
-            [
-              factory.createIdentifier('services'),
-              factory.createIdentifier('callbacks'),
-              factory.createIdentifier('options'),
-            ]
-          )
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          factory.createIdentifier('options'),
+          undefined,
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('CreateAPIBasicClientOptions'),
+            undefined
+          ),
+          undefined
         ),
       ],
-      true
-    )
-  );
+      factory.createTypeReferenceNode(
+        factory.createIdentifier('APIBasicClientServices'),
+        [
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('Services'),
+            undefined
+          ),
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('Callbacks'),
+            undefined
+          ),
+        ]
+      ),
+      undefined
+    ),
+    factory.createFunctionDeclaration(
+      [factory.createToken(ts.SyntaxKind.ExportKeyword)],
+      undefined,
+      factory.createIdentifier('createAPIClient'),
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          factory.createIdentifier('options'),
+          undefined,
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('CreateAPIClientOptions'),
+            undefined
+          ),
+          undefined
+        ),
+      ],
+      factory.createUnionTypeNode([
+        factory.createTypeReferenceNode(
+          factory.createIdentifier('Services'),
+          undefined
+        ),
+        factory.createTypeReferenceNode(
+          factory.createIdentifier('APIBasicClientServices'),
+          [
+            factory.createTypeReferenceNode(
+              factory.createIdentifier('Services'),
+              undefined
+            ),
+            factory.createTypeReferenceNode(
+              factory.createIdentifier('Callbacks'),
+              undefined
+            ),
+          ]
+        ),
+      ]),
+      factory.createBlock(
+        [
+          factory.createReturnStatement(
+            factory.createCallExpression(
+              factory.createIdentifier('qraftAPIClient'),
+              [
+                factory.createTypeReferenceNode(
+                  factory.createIdentifier('Services'),
+                  undefined
+                ),
+                factory.createTypeReferenceNode(
+                  factory.createIdentifier('Callbacks'),
+                  undefined
+                ),
+              ],
+              [
+                factory.createIdentifier('services'),
+                factory.createIdentifier('callbacks'),
+                factory.createIdentifier('options'),
+              ]
+            )
+          ),
+        ],
+        true
+      )
+    ),
+    factory.createTypeAliasDeclaration(
+      undefined,
+      factory.createIdentifier('Callbacks'),
+      undefined,
+      factory.createTypeQueryNode(
+        factory.createIdentifier('callbacks'),
+        undefined
+      )
+    ),
+  ];
 };

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,12 +1,4 @@
 import {
-  ComponentProps,
-  createContext,
-  ReactNode,
-  useContext,
-  useState,
-} from 'react';
-
-import {
   OperationSchema,
   QraftClientOptions,
   requestFn,
@@ -18,10 +10,15 @@ import {
   QueryClientProvider,
   useQueryClient,
 } from '@tanstack/react-query';
-
 import constate from 'constate';
-
-import { createAPIClient, Services, components } from './api';
+import {
+  ComponentProps,
+  createContext,
+  ReactNode,
+  useContext,
+  useState,
+} from 'react';
+import { components, createAPIClient, Services } from './api';
 
 function AppComponent() {
   const { petIdToEdit } = usePetToEdit();
@@ -415,12 +412,14 @@ export const QraftProviders = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export function useCreateAPIClient(options?: Partial<QraftClientOptions>) {
+function useCreateAPIClient(options?: Partial<QraftClientOptions>) {
   const apiContextValue = useContext(APIContext);
 
   const requestFn = options?.requestFn ?? apiContextValue?.requestFn;
   const baseUrl = options?.baseUrl ?? apiContextValue?.baseUrl;
-  const queryClient = useQueryClient(options?.queryClient);
+  const queryClient = useQueryClient(
+    options && 'queryClient' in options ? options?.queryClient : undefined
+  );
 
   if (!requestFn)
     throw new Error('requestFn not found in APIContext or options');

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,7 @@
     },
     "lint": {
       "cache": true,
-      "dependsOn": ["write-package-version-file", "^build"]
+      "dependsOn": ["write-package-version-file", "codegen", "^build"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
Updated the `qraftAPIClient(...)` to return only the set of services corresponding to the methods for which callbacks were passed.