### PR TITLE
docs(website): fix quick start instructions for the new version

### DIFF
--- a/packages/react-client/README.md
+++ b/packages/react-client/README.md
@@ -47,7 +47,7 @@ and schemas from your OpenAPI Document.
 To generate both TypeScript definitions and services using `openapi-qraft`, run the following command in the root directory of your project:
 
 ```bash
-npx @openapi-qraft/cli --plugin tanstack-query-react --plugin openapi-typescript https://api.dev.monite.com/openapi.json?version=2023-09-01 --output-dir src/api
+npx @openapi-qraft/cli@next --plugin tanstack-query-react --plugin openapi-typescript https://api.dev.monite.com/openapi.json?version=2023-09-01 --output-dir src/api
 ```
 
 By completing this step, you will generate `src/api/schema.d.ts`, which serves as a TypeScript representation of the specified OpenAPI,

--- a/website/docs/getting-started/quick-start.mdx
+++ b/website/docs/getting-started/quick-start.mdx
@@ -19,7 +19,7 @@ and also generate services that will use these types to interact with your API.
     Run the following command in the root directory of your project using your package manager.
 
     ```bash
-    npx @openapi-qraft/cli --plugin tanstack-query-react --plugin openapi-typescript \
+    npx @openapi-qraft/cli@next --plugin tanstack-query-react --plugin openapi-typescript \
       --output-dir src/api https://raw.githubusercontent.com/swagger-api/swagger-petstore/master/src/main/resources/openapi.yaml
     ```
   </TabItem>

--- a/website/versioned_docs/version-1.x/getting-started/quick-start.mdx
+++ b/website/versioned_docs/version-1.x/getting-started/quick-start.mdx
@@ -19,7 +19,7 @@ and also generate services that will use these types to interact with your API.
     Run the following command in the root directory of your project using your package manager.
 
     ```bash
-    npx @openapi-qraft/cli --plugin tanstack-query-react --plugin openapi-typescript \
+    npx @openapi-qraft/cli@next --plugin tanstack-query-react --plugin openapi-typescript \
       --output-dir src/api https://raw.githubusercontent.com/swagger-api/swagger-petstore/master/src/main/resources/openapi.yaml
     ```
   </TabItem>


### PR DESCRIPTION
Added `npm @openapi-qraft/cli@next` instructions.