### PR TITLE
fix(client-react): refine types related `qraftPredefinedParametersRequestFn(...)`

### DIFF
--- a/.changeset/sharp-wolves-nail.md
+++ b/.changeset/sharp-wolves-nail.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Refined all types related to value in the qraftPredefinedParametersRequestFn function.

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -89,3 +89,4 @@ workflows
 workspaces
 Ecks
 versioned
+TAsync

--- a/packages/react-client/src/tests/createPredefinedParametersRequestFn.test.ts
+++ b/packages/react-client/src/tests/createPredefinedParametersRequestFn.test.ts
@@ -1,0 +1,62 @@
+import { requestFn } from '@openapi-qraft/react';
+import { createPredefinedParametersRequestFn } from './fixtures/api/create-predefined-parameters-request-fn.js';
+
+describe('createPredefinedParametersRequestFn(...)', () => {
+  it('no emits type error', () => {
+    createPredefinedParametersRequestFn(
+      [
+        {
+          requestPattern: 'post /entities/{entity_id}/documents',
+          parameters: [
+            { name: 'x-monite-version', in: 'header', value: '2023-06-04' },
+          ],
+        },
+        {
+          requestPattern:
+            'get,delete,patch /approval_policies/{approval_policy_id}/**',
+          parameters: [
+            {
+              name: 'x-monite-entity-id',
+              in: 'header',
+              value: () => Promise.resolve('custom-entity-id'),
+            },
+          ],
+        },
+      ],
+      requestFn
+    );
+  });
+
+  it('emits type error', () => {
+    createPredefinedParametersRequestFn(
+      [
+        {
+          requestPattern: 'post /entities/{entity_id}/documents',
+          parameters: [
+            {
+              // @ts-expect-error - wrong name
+              name: 'x-monite-version!!',
+              in: 'header',
+              // @ts-expect-error - wrong value type
+              value: 111,
+            },
+          ],
+        },
+        {
+          requestPattern:
+            'get,delete,patch /approval_policies/{approval_policy_id}/**',
+          parameters: [
+            {
+              name: 'x-monite-entity-id',
+              // @ts-expect-error - wrong in usage
+              in: 'query',
+              // @ts-expect-error - wrong value type
+              value: () => Promise.resolve(999),
+            },
+          ],
+        },
+      ],
+      requestFn
+    );
+  });
+});


### PR DESCRIPTION
Refined all types related to `value` in the `qraftPredefinedParametersRequestFn` function to improve type safety and ensure correct handling of asynchronous values. 

This change introduces `QraftPredefinedParameterResolvedValue`, which better reflects the types of resolved values, and fixes potential issues with function and promise handling.