### PR TITLE
feat(react-client): allow `getQueryState(...)` to be called without `parameters`

### DIFF
--- a/.changeset/purple-pumpkins-mix.md
+++ b/.changeset/purple-pumpkins-mix.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Updated the `getQueryState` function to support being invoked without parameters if they are not required. This enhancement simplifies the usage in scenarios where the parameters are optional, providing a more flexible API.

--- a/packages/react-client/src/service-operation/ServiceOperationGetQueryState.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationGetQueryState.ts
@@ -4,18 +4,23 @@ import type {
   ServiceOperationInfiniteQueryKey,
   ServiceOperationQueryKey,
 } from './ServiceOperationKey.js';
+import { AreAllOptional } from '../lib/AreAllOptional.js';
 
 export interface ServiceOperationGetQueryState<
   TSchema extends { url: string; method: string },
   TData,
-  TParams = {},
+  TParams,
   TError = DefaultError,
 > {
   getQueryState(
-    parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>
+    parameters: AreAllOptional<TParams> extends true
+      ? TParams | ServiceOperationQueryKey<TSchema, TParams> | void
+      : TParams | ServiceOperationQueryKey<TSchema, TParams>
   ): QueryState<TData, TError> | undefined;
 
   getInfiniteQueryState(
-    parameters: TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>
+    parameters: AreAllOptional<TParams> extends true
+      ? TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams> | void
+      : TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>
   ): QueryState<OperationInfiniteData<TData, TParams>, TError> | undefined;
 }

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -2859,7 +2859,7 @@ describe('Qraft uses Queries Invalidation', () => {
     expect(result_02.current.isFetching).toBeTruthy();
   });
 
-  describe('Qraft uses getQueryState', () => {
+  describe('Qraft uses "getQueryState(...)"', () => {
     it('supports getQueryState by parameters', async () => {
       const { qraft, queryClient } = createClient({
         queryClientConfig: {
@@ -2924,6 +2924,30 @@ describe('Qraft uses Queries Invalidation', () => {
           )?.status
         ).toEqual('success');
       });
+    });
+
+    it('return Query state if no arguments provided', async () => {
+      const { qraft } = createClient();
+
+      renderHook(() => qraft.files.findAll.useQuery());
+
+      await waitFor(() =>
+        expect(qraft.files.findAll.getQueryState()).toMatchObject({
+          status: 'success',
+        })
+      );
+    });
+
+    it('respects input argument types', () => {
+      const { qraft } = createClient();
+
+      // not emits type error when all parameters are optional and no arguments provided
+      qraft.files.findAll.getInfiniteQueryState();
+
+      // @ts-expect-error - `parameters` is required
+      qraft.approvalPolicies.getApprovalPoliciesId.getQueryState();
+      // @ts-expect-error - `parameters` is required
+      qraft.approvalPolicies.getApprovalPoliciesId.getInfiniteQueryState();
     });
   });
 


### PR DESCRIPTION
Updated the `getQueryState` function to support being invoked without parameters if they are not required. This enhancement simplifies the usage in scenarios where the parameters are optional, providing a more flexible API.