### PR TITLE
fix(react-client): restrict input types for `getQueryKey` and `getMutationKey` to ensure type safety

### DIFF
--- a/.changeset/wise-feet-fry.md
+++ b/.changeset/wise-feet-fry.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Restricted `getQueryKey(...)` and `getMutationKey(...)` input types to ensure correct variable usage.

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/packages/react-client/src/service-operation/ServiceOperationUseMutation.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseMutation.ts
@@ -13,9 +13,9 @@ export interface ServiceOperationUseMutation<
   TParams,
   TError = DefaultError,
 > {
-  getMutationKey<TMutationKeyParams extends TParams | undefined = undefined>(
-    parameters?: TMutationKeyParams
-  ): ServiceOperationMutationKey<TSchema, TMutationKeyParams>;
+  getMutationKey(
+    parameters: TParams | void
+  ): ServiceOperationMutationKey<TSchema, TParams>;
 
   useMutation<
     TVariables extends MutationVariables<TBody, TParams>,

--- a/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts
@@ -11,12 +11,12 @@ import { AreAllOptional } from '../lib/AreAllOptional.js';
 export interface ServiceOperationUseQuery<
   TSchema extends { url: string; method: string },
   TQueryFnData,
-  TParams = {},
+  TParams,
   TError = DefaultError,
 > {
-  getQueryKey<QueryKeyParams extends TParams | undefined = undefined>(
-    parameters?: QueryKeyParams
-  ): ServiceOperationQueryKey<TSchema, QueryKeyParams>;
+  getQueryKey(
+    parameters: TParams | void
+  ): ServiceOperationQueryKey<TSchema, TParams>;
 
   useQuery<TData = TQueryFnData>(
     parameters:

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -3361,10 +3361,6 @@ describe('Qraft uses getMutationKey', () => {
         query: {
           referer: 'https://example.com',
         },
-        body: {
-          verification_document_back: 'back',
-          verification_document_front: 'front',
-        },
       })
     ).toEqual([
       {


### PR DESCRIPTION
Restricted `getQueryKey(...)` and `getMutationKey(...)` input types to ensure correct variable usage.