### PR TITLE
feat: add support for non-fetching actions with `qraftAPIClient(...)` using `{ queryClient }`

### DIFF
--- a/.changeset/curvy-lemons-breathe.md
+++ b/.changeset/curvy-lemons-breathe.md
@@ -1,0 +1,6 @@
+---
+"@openapi-qraft/tanstack-query-react-plugin": minor
+"@openapi-qraft/react": minor
+---
+
+Added support for calling `qraftAPIClient(...)` with `{ queryClient }`, enabling non-fetching actions like `resetQueries()`.

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -1,9 +1,11 @@
 export {
   qraftAPIClient,
   type CreateAPIClientOptions,
+  type CreateAPIBasicQueryClientOptions,
   type CreateAPIBasicClientOptions,
   type CreateAPIQueryClientOptions,
   type APIQueryClientServices,
+  type APIBasicQueryClientServices,
   type APIBasicClientServices,
   type APIUtilityClientServices,
   type QraftClientOptions,

--- a/packages/react-client/src/lib/callQueryClientFetchMethod.ts
+++ b/packages/react-client/src/lib/callQueryClientFetchMethod.ts
@@ -46,17 +46,19 @@ export function callQueryClientMethodWithQueryKey<
 
   const queryFn =
     queryFnOption ??
-    // @ts-expect-error - Too complex union to type
-    function ({ queryKey: [, queryParams], signal, meta, pageParam }) {
-      return requestFn(schema, {
-        parameters: infinite
-          ? (shelfMerge(2, queryParams, pageParam) as never)
-          : queryParams,
-        baseUrl,
-        signal,
-        meta,
-      }).then(requestFnResponseResolver, requestFnResponseResolver);
-    };
+    (requestFn
+      ? // @ts-expect-error - Too complex union to type
+        function ({ queryKey: [, queryParams], signal, meta, pageParam }) {
+          return requestFn(schema, {
+            parameters: infinite
+              ? (shelfMerge(2, queryParams, pageParam) as never)
+              : queryParams,
+            baseUrl,
+            signal,
+            meta,
+          }).then(requestFnResponseResolver, requestFnResponseResolver);
+        }
+      : undefined);
 
   // @ts-expect-error - Too complex union to type
   return queryClient[queryFilterMethod]({

--- a/packages/react-client/src/qraftAPIClient.ts
+++ b/packages/react-client/src/qraftAPIClient.ts
@@ -22,10 +22,13 @@ export interface CreateAPIBasicClientOptions {
   baseUrl: string;
 }
 
-export interface CreateAPIQueryClientOptions
-  extends CreateAPIBasicClientOptions {
+export interface CreateAPIBasicQueryClientOptions {
   queryClient: QueryClient;
 }
+
+export interface CreateAPIQueryClientOptions
+  extends CreateAPIBasicClientOptions,
+    CreateAPIBasicQueryClientOptions {}
 
 /**
  * @deprecated use `CreateAPIClientOptions` instead
@@ -36,6 +39,7 @@ export type QraftClientOptions =
 
 export type CreateAPIClientOptions =
   | CreateAPIBasicClientOptions
+  | CreateAPIBasicQueryClientOptions
   | CreateAPIQueryClientOptions;
 
 export function qraftAPIClient<
@@ -55,6 +59,15 @@ export function qraftAPIClient<
   callbacks: TCallbacks,
   options: CreateAPIQueryClientOptions
 ): Services;
+
+export function qraftAPIClient<
+  Services extends ServicesDeclaration<Services>,
+  TCallbacks extends Callbacks,
+>(
+  services: ServiceSchemasDeclaration<Services>,
+  callbacks: TCallbacks,
+  options: CreateAPIBasicQueryClientOptions
+): APIBasicQueryClientServices<Services, TCallbacks>;
 
 export function qraftAPIClient<
   Services extends ServicesDeclaration<Services>,
@@ -241,6 +254,38 @@ export type APIQueryClientServices<
   TCallbacks,
   QueryOperationCallbacks,
   MutationOperationCallbacks
+>;
+
+export type APIBasicQueryClientServices<
+  TServices extends ServicesDeclaration<TServices>,
+  TCallbacks extends Callbacks,
+> = ServicesFilteredByCallbacks<
+  TServices,
+  Omit<TCallbacks, 'operationInvokeFn'>,
+  Extract<
+    QueryOperationCallbacks,
+    | 'resetQueries'
+    | 'removeQueries'
+    | 'cancelQueries'
+    | 'invalidateQueries'
+    | 'refetchQueries'
+    | 'getQueryKey'
+    | 'getInfiniteQueryState'
+    | 'getInfiniteQueryData'
+    | 'getInfiniteQueryKey'
+    | 'setInfiniteQueryData'
+    | 'getQueriesData'
+    | 'setQueriesData'
+    | 'getQueryState'
+    | 'getQueryData'
+    | 'setQueryData'
+    | 'useIsFetching'
+    | 'isFetching'
+  >,
+  Extract<
+    MutationOperationCallbacks,
+    'getMutationKey' | 'useMutationState' | 'useIsMutating' | 'isMutating'
+  >
 >;
 
 export type APIUtilityClientServices<

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -1748,6 +1748,21 @@ describe('Qraft uses "fetchQuery(...) & "prefetchQuery(...)"', () => {
     ).rejects.toThrow(new Error('Failed to fetch'));
   });
 
+  it('throws an error if requestFn is not provided', async () => {
+    const qraft = createAPIClient({
+      queryClient: new QueryClient(),
+      // @ts-expect-error - incorrect usage case
+      requestFn: undefined,
+      baseUrl: 'http://any',
+    });
+
+    await expect(() => qraft.files.findAll.fetchQuery()).rejects.toThrow(
+      new Error(
+        `Missing queryFn: '${hashKey(qraft.files.findAll.getQueryKey())}'`
+      )
+    );
+  });
+
   it('uses fetchQuery with custom `baseUrl`', async () => {
     const requestFnSpy = vi.fn(requestFn);
 

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@openapi-qraft/react/callbacks/index';
 import { type QueryClientConfig } from '@tanstack/query-core';
 import {
+  hashKey,
   QueryClient,
   QueryClientProvider,
   useQueryClient,
@@ -17,7 +18,11 @@ import {
 import { act, renderHook, waitFor } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { vi } from 'vitest';
-import { CreateAPIClientOptions, qraftAPIClient, requestFn } from '../index.js';
+import {
+  CreateAPIQueryClientOptions,
+  qraftAPIClient,
+  requestFn,
+} from '../index.js';
 import { createPredefinedParametersRequestFn } from './fixtures/api/create-predefined-parameters-request-fn.js';
 import { createAPIClient, services, Services } from './fixtures/api/index.js';
 import { filesFindAllResponsePayloadFixtures } from './msw/handlers.js';
@@ -37,7 +42,7 @@ const createClient = ({
   requestFn: requestFnProp = requestFn,
   queryClientConfig,
 }: { queryClientConfig?: QueryClientConfig } & Partial<
-  Pick<CreateAPIClientOptions, 'requestFn'>
+  Pick<CreateAPIQueryClientOptions, 'requestFn'>
 > = {}) => {
   const queryClient = new QueryClient(queryClientConfig);
   return {
@@ -4223,7 +4228,7 @@ describe('Qraft is type-safe on Query Filters', () => {
   });
 });
 
-describe('Qraft is type-safe on if client created without options', () => {
+describe('Qraft is type-safe if client created without options', () => {
   it('does not throw an error', () => {
     const qraft = createAPIClient();
 
@@ -4260,6 +4265,37 @@ describe('Qraft is type-safe on if client created without options', () => {
     ).toThrow(
       new Error(`Cannot read properties of undefined (reading 'requestFn')`)
     );
+  });
+});
+
+describe('Qraft is type-safe if client created with "QueryClient" only', () => {
+  it('does not throw an error', () => {
+    const qraft = createAPIClient({ queryClient: new QueryClient() });
+
+    qraft.files.findAll.resetQueries();
+    qraft.files.findAll.removeQueries();
+    qraft.files.findAll.cancelQueries();
+    qraft.files.findAll.invalidateQueries();
+    qraft.files.findAll.getQueryKey();
+    qraft.files.findAll.getInfiniteQueryKey();
+
+    // query hooks
+    qraft.files.findAll.useIsFetching;
+
+    qraft.files.postFiles.getMutationKey();
+
+    // mutation hooks
+    qraft.files.postFiles.useIsMutating;
+    qraft.files.postFiles.useMutationState;
+  });
+
+  it('emits type error if requestFn is not provided', async () => {
+    const qraft = createAPIClient({ queryClient: new QueryClient() });
+
+    await expect(() =>
+      // @ts-expect-error - no options provided for the request - must emit an error
+      qraft.files.findAll.fetchQuery()
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/create-api-client.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/create-api-client.ts.snapshot.ts
@@ -3,15 +3,18 @@
  * Do not make direct changes to the file.
  */
 
-import { qraftAPIClient, type APIBasicClientServices, type APIUtilityClientServices, type CreateAPIBasicClientOptions, type CreateAPIClientOptions, type CreateAPIQueryClientOptions } from "@openapi-qraft/react";
+import { qraftAPIClient, type APIBasicClientServices, type APIBasicQueryClientServices, type APIUtilityClientServices, type CreateAPIBasicQueryClientOptions, type CreateAPIBasicClientOptions, type CreateAPIClientOptions, type CreateAPIQueryClientOptions } from "@openapi-qraft/react";
 import * as callbacks from "@openapi-qraft/react/callbacks/index";
 import { services, type Services } from "./services/index.js";
 export function createAPIClient(options: CreateAPIQueryClientOptions): Services;
+export function createAPIClient(options: CreateAPIBasicQueryClientOptions): APIBasicQueryClientServices<Services, ServiceMethods>;
 export function createAPIClient(options: CreateAPIBasicClientOptions): APIBasicClientServices<Services, ServiceMethods>;
 export function createAPIClient(): APIUtilityClientServices<Services, ServiceMethods>;
 export function createAPIClient(options?: CreateAPIClientOptions): Services | APIBasicClientServices<Services, ServiceMethods> | APIUtilityClientServices<Services, ServiceMethods> {
     if (!options)
         return qraftAPIClient<Services, ServiceMethods>(services, callbacks);
+    if ("requestFn" in options)
+        return qraftAPIClient<Services, ServiceMethods>(services, callbacks, options);
     return qraftAPIClient<Services, ServiceMethods>(services, callbacks, options);
 }
 type ServiceMethods = typeof callbacks;

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getClientFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getClientFactory.ts
@@ -32,7 +32,9 @@ const getClientImportsFactory = ({
           ),
           ...[
             'APIBasicClientServices',
+            'APIBasicQueryClientServices',
             'APIUtilityClientServices',
+            'CreateAPIBasicQueryClientOptions',
             'CreateAPIBasicClientOptions',
             'CreateAPIClientOptions',
             'CreateAPIQueryClientOptions',
@@ -109,6 +111,39 @@ const getCreateClientFunctionFactory = () => {
       factory.createTypeReferenceNode(
         factory.createIdentifier('Services'),
         undefined
+      ),
+      undefined
+    ),
+    factory.createFunctionDeclaration(
+      [factory.createToken(ts.SyntaxKind.ExportKeyword)],
+      undefined,
+      factory.createIdentifier('createAPIClient'),
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          factory.createIdentifier('options'),
+          undefined,
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('CreateAPIBasicQueryClientOptions'),
+            undefined
+          ),
+          undefined
+        ),
+      ],
+      factory.createTypeReferenceNode(
+        factory.createIdentifier('APIBasicQueryClientServices'),
+        [
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('Services'),
+            undefined
+          ),
+          factory.createTypeReferenceNode(
+            factory.createIdentifier('ServiceMethods'),
+            undefined
+          ),
+        ]
       ),
       undefined
     ),
@@ -239,6 +274,34 @@ const getCreateClientFunctionFactory = () => {
                 [
                   factory.createIdentifier('services'),
                   factory.createIdentifier('callbacks'),
+                ]
+              )
+            ),
+            undefined
+          ),
+          factory.createIfStatement(
+            factory.createBinaryExpression(
+              factory.createStringLiteral('requestFn'),
+              factory.createToken(ts.SyntaxKind.InKeyword),
+              factory.createIdentifier('options')
+            ),
+            factory.createReturnStatement(
+              factory.createCallExpression(
+                factory.createIdentifier('qraftAPIClient'),
+                [
+                  factory.createTypeReferenceNode(
+                    factory.createIdentifier('Services'),
+                    undefined
+                  ),
+                  factory.createTypeReferenceNode(
+                    factory.createIdentifier('ServiceMethods'),
+                    undefined
+                  ),
+                ],
+                [
+                  factory.createIdentifier('services'),
+                  factory.createIdentifier('callbacks'),
+                  factory.createIdentifier('options'),
                 ]
               )
             ),

--- a/website/docs/codegen/create-api-client-function.mdx
+++ b/website/docs/codegen/create-api-client-function.mdx
@@ -57,9 +57,27 @@ the necessary `requestFn`, `baseUrl` and `queryClient` for React Hooks.
     ### Returns
     - Qraft API client without `QueryClient`.
   </TabItem>
+  <TabItem value="only-query-client" label={<>Only&nbsp;<span style={{verticalAlign: 'middle'}}><code>QueryClient</code>&nbsp;🔧</span></>}>
+    If you need to type-safe `QueryClient` methods like `setQueryData()`, `getQueryState()`, or `invalidateQueries()`,
+    you can create an API client with only `QueryClient` provided.
+
+    ```tsx
+    import { createAPIClient } from './api'
+
+    const api = createAPIClient({ queryClient })
+    ```
+
+    ### Arguments
+    1. `options: QraftClientOptions` - **Required** options to be used by the Qraft API client
+       - `options.queryClient` - **Required** `QueryClient` instance to be used by Qraft Hooks.
+
+    ### Returns
+    - Qraft API client without request methods and React Hooks.
+  </TabItem>
+
   <TabItem value="no-query-client" label={<>No requests&nbsp;<span style={{textDecoration: 'line-through', color: 'red'}}>🛜</span></>}>
     If you only need to type `QueryKey` or `MutationKey`, you can create an API client without options.
-    In this case, be prepared that only methods that create typed `QueryKey` or `MutationKey` will be available.
+    In this case, be aware that only methods that create typed `QueryKey` or `MutationKey` will be available.
 
     ```tsx
     import { createAPIClient } from './api'


### PR DESCRIPTION
- Support for calling `qraftAPIClient(...)` with `{ queryClient }`, enabling non-fetching actions like `resetQueries()`.
- Ensures that `queryFn` is not created when `requestFn` is provided in `callQueryClientMethodWithQueryKey(...)`, avoiding unnecessary fetch logic.