### PR TITLE
fix(react-client): add missing dist file for `qraftPredefinedParametersRequestFn`

### DIFF
--- a/.changeset/two-lions-burn.md
+++ b/.changeset/two-lions-burn.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/tanstack-query-react-plugin": patch
+---
+
+Use `import type` for types in generated `qraftPredefinedParametersRequestFn`.

--- a/.changeset/witty-cobras-kiss.md
+++ b/.changeset/witty-cobras-kiss.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Added missing dist file for `qraftPredefinedParametersRequestFn`.

--- a/e2e/projects/typescript-commonjs-node/package.json
+++ b/e2e/projects/typescript-commonjs-node/package.json
@@ -7,7 +7,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc",
-    "codegen": "openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript https://raw.githubusercontent.com/swagger-api/swagger-petstore/7767363b841961221a38c0be9c6b1066a5120051/src/main/resources/openapi.yaml --clean -o src/api --openapi-types-import-path '../schema.d.ts' --openapi-types-file-name schema.d.ts",
+    "codegen": "openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript https://raw.githubusercontent.com/swagger-api/swagger-petstore/7767363b841961221a38c0be9c6b1066a5120051/src/main/resources/openapi.yaml --clean -o src/api --openapi-types-import-path '../schema.d.ts' --openapi-types-file-name schema.d.ts --operation-predefined-parameters /pet/findByStatus:query.status",
     "e2e:pre-build": "npm run codegen",
     "e2e:post-build": "node ./dist/index.js"
   },

--- a/packages/react-client/rollup.config.mjs
+++ b/packages/react-client/rollup.config.mjs
@@ -10,6 +10,9 @@ const config = [
   rollupConfig(moduleDist, { input: 'src/index.ts' }),
   rollupConfig(moduleDist, { input: 'src/callbacks/index.ts' }),
   rollupConfig(moduleDist, { input: 'src/Unstable_QraftSecureRequestFn.ts' }),
+  rollupConfig(moduleDist, {
+    input: 'src/qraftPredefinedParametersRequestFn.ts',
+  }),
 ];
 
 export default config;

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/operation-predefined-parameters/create-predefined-parameters-request-fn.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/operation-predefined-parameters/create-predefined-parameters-request-fn.ts.snapshot.ts
@@ -4,8 +4,8 @@
  */
 
 import type { RequestFn } from "@openapi-qraft/react";
-import { qraftPredefinedParametersRequestFn, QraftPredefinedParameterValue } from "@openapi-qraft/react/qraftPredefinedParametersRequestFn";
-import { paths } from "./../openapi.d.ts";
+import { qraftPredefinedParametersRequestFn, type QraftPredefinedParameterValue } from "@openapi-qraft/react/qraftPredefinedParametersRequestFn";
+import type { paths } from "./../openapi.d.ts";
 export type ServiceOperationsPredefinedParameters = [
     {
         requestPattern: "post /entities/{entity_id}/documents";

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getCreatePredefinedParametersRequestFnFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getCreatePredefinedParametersRequestFnFactory.ts
@@ -59,7 +59,7 @@ const getCreatePredefinedParametersRequestFnImportsFactory = ({
             factory.createIdentifier('qraftPredefinedParametersRequestFn')
           ),
           factory.createImportSpecifier(
-            false,
+            true,
             undefined,
             factory.createIdentifier('QraftPredefinedParameterValue')
           ),
@@ -73,7 +73,7 @@ const getCreatePredefinedParametersRequestFnImportsFactory = ({
     factory.createImportDeclaration(
       undefined,
       factory.createImportClause(
-        false,
+        true,
         undefined,
         factory.createNamedImports([
           factory.createImportSpecifier(


### PR DESCRIPTION
- Added `src/qraftPredefinedParametersRequestFn.ts` as an entry point to Rollup.
- Added `--operation-predefined-parameters` option usage to `typescript-commonjs-node` e2e test case.
- Use `import type` for types in generated `qraftPredefinedParametersRequestFn`.