### PR TITLE
fix(react-client): enforce stricter typing for `RequestFnResponse`

### DIFF
--- a/.changeset/hip-ducks-love.md
+++ b/.changeset/hip-ducks-love.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Made `RequestFnResponse` type more strict.

--- a/packages/react-client/src/lib/requestFn.ts
+++ b/packages/react-client/src/lib/requestFn.ts
@@ -404,21 +404,21 @@ export type RequestFn<TData, TError> = typeof requestFn<TData, TError>;
 
 export type RequestFnResponse<TData, TError> =
   | {
-      data?: TData;
+      data: TData;
       response: Response;
-      error?: never;
+      error?: undefined;
     }
   | {
       // server error
-      error?: TError | Error;
+      data?: undefined;
       response: Response;
-      data?: never;
+      error: TError | Error;
     }
   | {
       // network error
-      error?: Error;
-      data?: never;
-      response?: never;
+      data?: undefined;
+      response?: undefined;
+      error: Error;
     };
 
 type WithRequired<T, K extends keyof T> = T & {

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -2312,6 +2312,18 @@ describe('Custom Callbacks support', () => {
         },
       });
 
+      // @ts-expect-error - not yet inferred, `data` could be `undefined`
+      data.body;
+      data?.body; // `data` could be `undefined`, but `body` is a correct type
+      if (!error) {
+        data.body; // should be inferred because `error` is undefined
+      } else {
+        // @ts-expect-error - if error is defined, `data` is empty
+        data.body;
+        // @ts-expect-error - if error is defined, `body` is not a correct type
+        data?.body;
+      }
+
       expect(
         error satisfies
           | Services['entities']['postEntitiesIdDocuments']['types']['error']


### PR DESCRIPTION
Enhanced the `RequestFnResponse` type in the `@openapi-qraft/react` package to enforce stricter typing.