### PR TITLE
chore(react-client): improve parameter types for `useSuspenseInfiniteQuery(...)` and `useSuspenseQuery(...)`

### DIFF
--- a/.changeset/good-lizards-grow.md
+++ b/.changeset/good-lizards-grow.md
@@ -1,0 +1,5 @@
+---
+"@openapi-qraft/react": patch
+---
+
+Improved parameter types for `useSuspenseInfiniteQuery(...)` and `useSuspenseQuery(...)`.

--- a/packages/react-client/src/service-operation/ServiceOperationUseInfiniteQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseInfiniteQuery.ts
@@ -24,9 +24,9 @@ export interface ServiceOperationUseInfiniteQuery<
   ): ServiceOperationInfiniteQueryKey<TSchema, TParams>;
 
   useInfiniteQuery<TPageParam extends TParams, TData = TQueryFnData>(
-    parameters: AreAllOptional<TParams> extends true
-      ? TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams> | void
-      : TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
+    parameters:
+      | ServiceOperationInfiniteQueryKey<TSchema, TParams>
+      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
     options: Omit<
       UndefinedInitialDataInfiniteOptions<
         TQueryFnData,
@@ -50,9 +50,9 @@ export interface ServiceOperationUseInfiniteQuery<
   >;
 
   useInfiniteQuery<TPageParam extends TParams, TData = TQueryFnData>(
-    parameters: AreAllOptional<TParams> extends true
-      ? TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams> | void
-      : TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
+    parameters:
+      | ServiceOperationInfiniteQueryKey<TSchema, TParams>
+      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
     options: Omit<
       DefinedInitialDataInfiniteOptions<
         TQueryFnData,

--- a/packages/react-client/src/service-operation/ServiceOperationUseSuspenseInfiniteQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseSuspenseInfiniteQuery.ts
@@ -9,15 +9,18 @@ import type {
 import type { PartialParameters } from '../lib/PartialParameters.type.js';
 import type { OperationInfiniteData } from './OperationInfiniteData.js';
 import type { ServiceOperationInfiniteQueryKey } from './ServiceOperationKey.js';
+import { AreAllOptional } from '../lib/AreAllOptional.js';
 
 export interface ServiceOperationUseSuspenseInfiniteQuery<
   TSchema extends { url: string; method: string },
   TQueryFnData,
-  TParams = {},
+  TParams,
   TError = DefaultError,
 > {
   useSuspenseInfiniteQuery<TPageParam extends TParams, TData = TQueryFnData>(
-    parameters: TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
+    parameters:
+      | ServiceOperationInfiniteQueryKey<TSchema, TParams>
+      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
     options: Omit<
       UseSuspenseInfiniteQueryOptions<
         TQueryFnData,

--- a/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQuery.ts
+++ b/packages/react-client/src/service-operation/ServiceOperationUseSuspenseQuery.ts
@@ -4,15 +4,18 @@ import type {
   UseSuspenseQueryResult,
 } from '@tanstack/react-query';
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
+import { AreAllOptional } from '../lib/AreAllOptional.js';
 
 export interface ServiceOperationUseSuspenseQuery<
   TSchema extends { url: string; method: string },
   TQueryFnData,
-  TParams = {},
+  TParams,
   TError = DefaultError,
 > {
   useSuspenseQuery<TData = TQueryFnData>(
-    parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
+    parameters:
+      | ServiceOperationQueryKey<TSchema, TParams>
+      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
     options?: Omit<
       UseSuspenseQueryOptions<
         TQueryFnData,

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -248,6 +248,25 @@ describe('Qraft uses Suspense Query', () => {
       },
     });
   });
+
+  it('not emits type error if optional parameters are not provided', async () => {
+    const { qraft } = createClient();
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function testTsTypes() {
+      qraft.files.findAll.useSuspenseQuery();
+    }
+  });
+
+  it('emits type error if required parameters are not provided', async () => {
+    const { qraft } = createClient();
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function testTsTypes() {
+      // @ts-expect-error - no parameters
+      qraft.approvalPolicies.getApprovalPoliciesId.useSuspenseQuery();
+    }
+  });
 });
 
 describe('Qraft uses Queries', () => {
@@ -822,6 +841,29 @@ describe('Qraft uses Suspense Infinite Queries', () => {
         },
       ],
     });
+  });
+
+  it('not emits type error if optional parameters are not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function testTsTypes() {
+      const { qraft } = createClient();
+
+      qraft.files.findAll.useSuspenseInfiniteQuery(undefined, {
+        getNextPageParam: () => {
+          return {};
+        },
+        initialPageParam: {},
+      });
+    }
+  });
+
+  it('emits type error if required parameters are not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function testTsTypes() {
+      const { qraft } = createClient();
+      // @ts-expect-error - no parameters
+      qraft.files.getFiles.useSuspenseInfiniteQuery();
+    }
   });
 });
 


### PR DESCRIPTION
Refined the parameter types for both `useSuspenseInfiniteQuery(...)` and `useSuspenseQuery(...)` in the `react-client` package.