### PR TITLE
feat(plugin): generate comprehensive operation names with service name base option

### DIFF
--- a/.changeset/good-eagles-help.md
+++ b/.changeset/good-eagles-help.md
@@ -1,0 +1,25 @@
+---
+'@openapi-qraft/plugin': major
+'@openapi-qraft/cli': major
+---
+
+Generate comprehensive operation names with consideration of the `--service-name-base` option. Operation names now
+include all path parts and parameters, and the structure can be customized based on the `--service-name-base` value.
+
+Breaking Changes:
+
+- Operation names now include all path parts and parameters by default.
+- `/api/v{api-version}` is no longer automatically removed from the path when generating names.
+- The `--service-name-base` option now influences the generated operation name.
+
+Examples:
+
+- With `--service-name-base=endpoint[0]`:
+  POST /api/v1/users/{id} → postApiV1UsersId
+- With `--service-name-base=tags`:
+  POST /api/v1/users/{id}/{key} → postApiV1UsersIdKey
+- With `--service-name-base=endpoint[2]`:
+  POST /api/v1/users/{id}/{key} → postUsersIdKey
+
+This change provides more flexibility in operation name generation and allows for better customization based on project
+requirements.

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -95,3 +95,4 @@ codemod
 jscodeshift
 webhooks
 tsdoc
+Vapi

--- a/packages/plugin/src/lib/open-api/getOperationName.spec.ts
+++ b/packages/plugin/src/lib/open-api/getOperationName.spec.ts
@@ -3,15 +3,6 @@ import { getOperationName } from './getOperationName.js';
 
 describe('getOperationName', () => {
   it('should produce correct result', () => {
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'GetAllUsers')
-    ).toEqual('getAllUsers');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', undefined)
-    ).toEqual('getApiUsers');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'POST', undefined)
-    ).toEqual('postApiUsers');
     expect(getOperationName('/api/v1/users', 'GET', 'GetAllUsers')).toEqual(
       'getAllUsers'
     );
@@ -22,47 +13,31 @@ describe('getOperationName', () => {
       'postApiV1Users'
     );
     expect(getOperationName('/api/v1/users/{id}', 'GET', undefined)).toEqual(
-      'getApiV1Users'
+      'getApiV1UsersId'
     );
     expect(getOperationName('/api/v1/users/{id}', 'POST', undefined)).toEqual(
-      'postApiV1Users'
+      'postApiV1UsersId'
     );
+    expect(
+      getOperationName('/api/v1/users/{id}/{key}', 'POST', undefined)
+    ).toEqual('postApiV1UsersIdKey');
 
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'fooBar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'FooBar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'Foo Bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'foo bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'foo-bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'foo_bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', 'foo.bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', '@foo.bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', '$foo.bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', '_foo.bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', '-foo.bar')
-    ).toEqual('fooBar');
-    expect(
-      getOperationName('/api/v{api-version}/users', 'GET', '123.foo.bar')
-    ).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'fooBar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'FooBar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'Foo Bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'foo bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'foo-bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'foo_bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', '@foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', '$foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', '_foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', '-foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', '123.foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', '123.foo.bar')).toEqual('fooBar');
   });
+
+  expect(
+    getOperationName('/api/v{api-version}/users', 'GET', undefined)
+  ).toEqual('getApiVapiVersionUsers');
 });

--- a/packages/plugin/src/lib/open-api/getOperationName.spec.ts
+++ b/packages/plugin/src/lib/open-api/getOperationName.spec.ts
@@ -3,41 +3,75 @@ import { getOperationName } from './getOperationName.js';
 
 describe('getOperationName', () => {
   it('should produce correct result', () => {
-    expect(getOperationName('/api/v1/users', 'GET', 'GetAllUsers')).toEqual(
-      'getAllUsers'
-    );
-    expect(getOperationName('/api/v1/users', 'GET', undefined)).toEqual(
+    expect(
+      getOperationName('/api/v1/users', 'GET', 'GetAllUsers', 'tags')
+    ).toEqual('getAllUsers');
+    expect(getOperationName('/api/v1/users', 'GET', undefined, 'tags')).toEqual(
       'getApiV1Users'
     );
-    expect(getOperationName('/api/v1/users', 'POST', undefined)).toEqual(
-      'postApiV1Users'
-    );
-    expect(getOperationName('/api/v1/users/{id}', 'GET', undefined)).toEqual(
-      'getApiV1UsersId'
-    );
-    expect(getOperationName('/api/v1/users/{id}', 'POST', undefined)).toEqual(
-      'postApiV1UsersId'
-    );
     expect(
-      getOperationName('/api/v1/users/{id}/{key}', 'POST', undefined)
+      getOperationName('/api/v1/users', 'POST', undefined, 'tags')
+    ).toEqual('postApiV1Users');
+    expect(
+      getOperationName('/api/v1/users/{id}', 'GET', undefined, 'tags')
+    ).toEqual('getApiV1UsersId');
+    expect(
+      getOperationName('/api/v1/users/{id}', 'POST', undefined, 'endpoint[0]')
+    ).toEqual('postApiV1UsersId');
+    expect(
+      getOperationName('/api/v1/users/{id}/{key}', 'POST', undefined, 'tags')
     ).toEqual('postApiV1UsersIdKey');
+    expect(
+      getOperationName(
+        '/api/v1/users/{id}/{key}',
+        'POST',
+        undefined,
+        'endpoint[2]'
+      )
+    ).toEqual('postUsersIdKey');
 
-    expect(getOperationName('/users', 'GET', 'fooBar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', 'FooBar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', 'Foo Bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', 'foo bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', 'foo-bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', 'foo_bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', 'foo.bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', '@foo.bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', '$foo.bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', '_foo.bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', '-foo.bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', '123.foo.bar')).toEqual('fooBar');
-    expect(getOperationName('/users', 'GET', '123.foo.bar')).toEqual('fooBar');
+    expect(getOperationName('/users', 'GET', 'fooBar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', 'FooBar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', 'Foo Bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', 'foo bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', 'foo-bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', 'foo_bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', 'foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', '@foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', '$foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', '_foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', '-foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', '123.foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
+    expect(getOperationName('/users', 'GET', '123.foo.bar', 'tags')).toEqual(
+      'fooBar'
+    );
   });
 
   expect(
-    getOperationName('/api/v{api-version}/users', 'GET', undefined)
+    getOperationName('/api/v{api-version}/users', 'GET', undefined, 'tags')
   ).toEqual('getApiVapiVersionUsers');
 });

--- a/packages/plugin/src/lib/open-api/getOperationName.ts
+++ b/packages/plugin/src/lib/open-api/getOperationName.ts
@@ -1,4 +1,7 @@
-import camelCase from 'camelcase';
+import type { ServiceBaseNameByEndpointOption } from './getServiceNamesByOperationEndpoint.js';
+import type { ServiceBaseName } from './getServices.js';
+import camelcase from 'camelcase';
+import { getEndpointPartIndex } from './getServiceNamesByOperationEndpoint.js';
 
 /**
  * Convert the input value to a correct operation (method) classname.
@@ -8,22 +11,39 @@ import camelCase from 'camelcase';
 export const getOperationName = (
   url: string,
   method: string,
-  operationId: string | undefined
+  operationId: string | undefined,
+  serviceNameBase: ServiceBaseName
 ): string => {
   if (operationId) return getOperationIdName(operationId);
 
-  const urlWithoutPlaceholders = url
+  const urlWithoutPlaceholders = (
+    serviceNameBase === 'tags'
+      ? url
+      : reduceUrlByEndpointPartIndex(url, serviceNameBase)
+  )
     .replace(/{(.*?)}/g, '$1')
     .replace(/\//g, '-');
 
-  return camelCase(`${method}-${urlWithoutPlaceholders}`);
+  return camelcase(`${method}-${urlWithoutPlaceholders}`);
 };
 
 export const getOperationIdName = (operationId: string): string => {
-  return camelCase(
+  return camelcase(
     operationId
       .replace(/^[^a-zA-Z]+/g, '')
       .replace(/[^\w-]+/g, '-')
       .trim()
   );
+};
+
+export const reduceUrlByEndpointPartIndex = (
+  url: string,
+  serviceNameBase: ServiceBaseNameByEndpointOption
+) => {
+  const reducedPath = (url.startsWith('/') ? url.slice(1) : url)
+    .split('/')
+    .slice(getEndpointPartIndex(serviceNameBase))
+    .join('/');
+
+  return url.startsWith('/') ? `/${reducedPath}` : reducedPath;
 };

--- a/packages/plugin/src/lib/open-api/getOperationName.ts
+++ b/packages/plugin/src/lib/open-api/getOperationName.ts
@@ -13,8 +13,7 @@ export const getOperationName = (
   if (operationId) return getOperationIdName(operationId);
 
   const urlWithoutPlaceholders = url
-    .replace(/[^/]*?{api-version}.*?\//g, '')
-    .replace(/{(.*?)}/g, '')
+    .replace(/{(.*?)}/g, '$1')
     .replace(/\//g, '-');
 
   return camelCase(`${method}-${urlWithoutPlaceholders}`);

--- a/packages/plugin/src/lib/open-api/getServiceName.spec.ts
+++ b/packages/plugin/src/lib/open-api/getServiceName.spec.ts
@@ -1,17 +1,31 @@
 import { describe, expect, it } from 'vitest';
+import { reduceUrlByEndpointPartIndex } from './getOperationName.js';
 import { getServiceName } from './getServiceName.js';
 
-describe('getServiceName', () => {
-  it('should produce correct result', () => {
-    expect(getServiceName('')).toEqual('');
-    expect(getServiceName('FooBar')).toEqual('FooBar');
-    expect(getServiceName('Foo Bar')).toEqual('FooBar');
-    expect(getServiceName('foo bar')).toEqual('FooBar');
-    expect(getServiceName('@fooBar')).toEqual('FooBar');
-    expect(getServiceName('$fooBar')).toEqual('FooBar');
-    expect(getServiceName('123fooBar')).toEqual('FooBar');
-    expect(getServiceName('foo-bar')).toEqual('FooBar');
-    expect(getServiceName('foo bar')).toEqual('FooBar');
-    expect(getServiceName('foo_bar')).toEqual('FooBar');
+describe('# getServiceName', () => {
+  describe('getServiceName()', () => {
+    it('should produce correct result', () => {
+      expect(getServiceName('')).toEqual('');
+      expect(getServiceName('FooBar')).toEqual('FooBar');
+      expect(getServiceName('Foo Bar')).toEqual('FooBar');
+      expect(getServiceName('foo bar')).toEqual('FooBar');
+      expect(getServiceName('@fooBar')).toEqual('FooBar');
+      expect(getServiceName('$fooBar')).toEqual('FooBar');
+      expect(getServiceName('123fooBar')).toEqual('FooBar');
+      expect(getServiceName('foo-bar')).toEqual('FooBar');
+      expect(getServiceName('foo bar')).toEqual('FooBar');
+      expect(getServiceName('foo_bar')).toEqual('FooBar');
+    });
+  });
+
+  describe('reduceUrlByEndpointPartIndex()', () => {
+    it('should produce correct result', () => {
+      expect(
+        reduceUrlByEndpointPartIndex('/api/v1/users', 'endpoint[2]')
+      ).toEqual('/users');
+      expect(
+        reduceUrlByEndpointPartIndex('api/v1/users', 'endpoint[1]')
+      ).toEqual('v1/users');
+    });
   });
 });

--- a/packages/plugin/src/lib/open-api/getServices.ts
+++ b/packages/plugin/src/lib/open-api/getServices.ts
@@ -141,7 +141,12 @@ export const getServices = (
           method,
           path,
           errors,
-          name: getOperationName(path, method, methodOperation.operationId),
+          name: getOperationName(
+            path,
+            method,
+            methodOperation.operationId,
+            serviceNameBase
+          ),
           description: methodOperation.description,
           summary: methodOperation.summary,
           deprecated: methodOperation.deprecated,


### PR DESCRIPTION
1. Operation names now include all path parts and parameters.
2. The `/api/v{api-version}` part of the path is now retained in the operation name.
3. The `--service-name-base` option is now taken into account when generating operation names.

## Breaking Changes
- The structure of generated operation names has changed, which may affect existing code that relies on the previous naming convention.
- `/api/v{api-version}` is no longer automatically removed from the path when generating names.
- The `--service-name-base` option now influences the generated operation name.

## Examples
Here are examples of how operation names are now generated based on different `--service-name-base` options:

1. With `--service-name-base=endpoint[0]`:
   ```
   POST /api/v1/users/{id} → postApiV1UsersId
   ```

2. With `--service-name-base=tags`:
   ```
   POST /api/v1/users/{id}/{key} → postApiV1UsersIdKey
   ```

3. With `--service-name-base=endpoint[2]`:
   ```
   POST /api/v1/users/{id}/{key} → postUsersIdKey
   ```

## Motivation
This change improves the flexibility and customization of generated operation names by:
- Including all parts of the API path for more unique and descriptive names.
- Allowing users to control which parts of the path are included in the name through the `--service-name-base` option.