### PR TITLE
feat(plugin): update operation name generation 🧁

### DIFF
--- a/.changeset/good-eagles-help.md
+++ b/.changeset/good-eagles-help.md
@@ -6,20 +6,24 @@
 Generate comprehensive operation names with consideration of the `--service-name-base` option. Operation names now
 include all path parts and parameters, and the structure can be customized based on the `--service-name-base` value.
 
-Breaking Changes:
+**Breaking Changes:**
 
 - Operation names now include all path parts and parameters by default.
-- `/api/v{api-version}` is no longer automatically removed from the path when generating names.
-- The `--service-name-base` option now influences the generated operation name.
+- `/api/v{api-version}` is no longer automatically removed from the path when generating operation names.
+- The `--service-name-base` option now influences the generated operation names with a new structure.
 
-Examples:
+**Examples:**
 
 - With `--service-name-base=endpoint[0]`:
-  POST /api/v1/users/{id} → postApiV1UsersId
+  `POST /v1/users/{id}` → `api.v1.postUsersId`
+- With `--service-name-base=endpoint[1]`:
+  `GET /v1/users/{id}` → `api.users.getId`
+- With `--service-name-base=endpoint[1]`:
+  `POST /v1/users/suspend` → `api.users.postSuspend`
+- With `--service-name-base=endpoint[1]`:
+  `POST /v1/users/{id}/{key}` → `api.postIdKey`
 - With `--service-name-base=tags`:
-  POST /api/v1/users/{id}/{key} → postApiV1UsersIdKey
-- With `--service-name-base=endpoint[2]`:
-  POST /api/v1/users/{id}/{key} → postUsersIdKey
+  `POST /v1/users/{id}/{key}` → `api.<tag>.postV1UsersIdKey`
 
 This change provides more flexibility in operation name generation and allows for better customization based on project
 requirements.

--- a/packages/plugin/src/lib/open-api/getOperationName.spec.ts
+++ b/packages/plugin/src/lib/open-api/getOperationName.spec.ts
@@ -17,7 +17,7 @@ describe('getOperationName', () => {
     ).toEqual('getApiV1UsersId');
     expect(
       getOperationName('/api/v1/users/{id}', 'POST', undefined, 'endpoint[0]')
-    ).toEqual('postApiV1UsersId');
+    ).toEqual('postV1UsersId');
     expect(
       getOperationName('/api/v1/users/{id}/{key}', 'POST', undefined, 'tags')
     ).toEqual('postApiV1UsersIdKey');
@@ -28,7 +28,7 @@ describe('getOperationName', () => {
         undefined,
         'endpoint[2]'
       )
-    ).toEqual('postUsersIdKey');
+    ).toEqual('postIdKey');
 
     expect(getOperationName('/users', 'GET', 'fooBar', 'tags')).toEqual(
       'fooBar'

--- a/packages/plugin/src/lib/open-api/getOperationName.ts
+++ b/packages/plugin/src/lib/open-api/getOperationName.ts
@@ -40,10 +40,18 @@ export const reduceUrlByEndpointPartIndex = (
   url: string,
   serviceNameBase: ServiceBaseNameByEndpointOption
 ) => {
-  const reducedPath = (url.startsWith('/') ? url.slice(1) : url)
-    .split('/')
-    .slice(getEndpointPartIndex(serviceNameBase))
-    .join('/');
+  const pathSegments = (url.startsWith('/') ? url.slice(1) : url).split('/');
+
+  // skip the first segment
+  const pathOperationNameStartIndex = getEndpointPartIndex(serviceNameBase) + 1;
+
+  if (pathSegments.length + 1 <= pathOperationNameStartIndex) {
+    throw new Error(
+      `Invalid service name base '${serviceNameBase}'. The path '${url}' does not contain enough segments to generate a service name.`
+    );
+  }
+
+  const reducedPath = pathSegments.slice(pathOperationNameStartIndex).join('/');
 
   return url.startsWith('/') ? `/${reducedPath}` : reducedPath;
 };

--- a/packages/plugin/src/lib/open-api/getServiceName.spec.ts
+++ b/packages/plugin/src/lib/open-api/getServiceName.spec.ts
@@ -19,13 +19,38 @@ describe('# getServiceName', () => {
   });
 
   describe('reduceUrlByEndpointPartIndex()', () => {
-    it('should produce correct result', () => {
+    it('produces correct result if the path has the same number of segments as the endpoint index', () => {
       expect(
         reduceUrlByEndpointPartIndex('/api/v1/users', 'endpoint[2]')
-      ).toEqual('/users');
+      ).toEqual('/');
+    });
+
+    it('produces correct result if the path has more segments than the endpoint index', () => {
+      expect(
+        reduceUrlByEndpointPartIndex('/api/v1/users/all', 'endpoint[2]')
+      ).toEqual('/all');
+    });
+
+    it('produces correct result if the path has more segments than the endpoint index and no leading slash', () => {
+      expect(
+        reduceUrlByEndpointPartIndex('api/v1/users/all', 'endpoint[2]')
+      ).toEqual('all');
+
       expect(
         reduceUrlByEndpointPartIndex('api/v1/users', 'endpoint[1]')
-      ).toEqual('v1/users');
+      ).toEqual('users');
+    });
+
+    it('produces correct result if the path has the same number of segments as the endpoint index and no leading slash', () => {
+      expect(reduceUrlByEndpointPartIndex('users', 'endpoint[0]')).toEqual('');
+    });
+
+    it('throws an error if the path has fewer segments than the endpoint index', () => {
+      expect(() =>
+        reduceUrlByEndpointPartIndex('/v1/users', 'endpoint[2]')
+      ).toThrowError(
+        "Invalid service name base 'endpoint[2]'. The path '/v1/users' does not contain enough segments to generate a service name."
+      );
     });
   });
 });

--- a/website/docs/codegen/CLI/cli.mdx
+++ b/website/docs/codegen/CLI/cli.mdx
@@ -98,13 +98,23 @@ npx openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript http
     - `--operation-name-modifier 'post /files ==> createOne' 'put /posts ==> updateOne'` - will change all `POST` operations under `/files` to `createOne` and all `PUT` operations under `/posts` to `updateOne`.
 
 - **`--service-name-base <endpoint[<index>] | tags>`:** Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: `/0/1/2`) or `tags` as the base name of the service. _(optional, default: `endpoint[0]`)_.
-  - Examples:
-    - `--service-name-base endpoint[0]` generates `services/FooService.ts` for the endpoint `/foo/bar/baz`
-    - `--service-name-base endpoint[1]` generates `services/BarService.ts` for the endpoint `/foo/bar/baz`
-    - `--service-name-base endpoint[3]` generates `services/BazService.ts` for the endpoint `/foo/bar/baz` _(if the endpoint is shorter than the index, the last part is used)_
-    - `--service-name-base tags` will generate services based on the OpenAPI Operation tags instead of the endpoint.
-      - If multiple tags are present for the operation, similar services will be created for each tag. Operation with `tags: [Foo, Bar]` will generate `services/FooService.ts` and `services/BarService.ts`.
-      - If there are no tags for the operation, the services will be created under the `default` tag. Operation with empty `tags: []` will generate `services/DefaultService.ts`.
+  - **`endpoint[<index>]`** - Use the path segment (e.g., `/0/1/2`) as the base name for the service.
+    - Examples:
+      - `--service-name-base endpoint[0]` generates `services/FooService.ts` for the endpoint `/foo/bar/baz`
+      - `--service-name-base endpoint[1]` generates `services/BarService.ts` for the endpoint `/foo/bar/baz`
+      - `--service-name-base endpoint[3]` generates `services/BazService.ts` for the endpoint `/foo/bar/baz` _(if the endpoint is shorter than the index, the last part is used)_
+      - If used `endpoint[<index>]` as the base name, operation names will be generated according to the specified index.
+        - For example:
+          - `--service-name-base endpoint[1]` for the endpoint `/api/bar` generates `get` operation name.
+          - `--service-name-base endpoint[1]` for the endpoint `/api/foo/bar` generates `getBar` operation name.
+  - **`tags`** - Use the OpenAPI Operation `tags` as the base name of the service.
+    - Examples:
+      - `--service-name-base tags` will generate services based on the OpenAPI Operation tags instead of the endpoint.
+        - If multiple tags are present for the operation, similar services will be created for each tag. Operation with `tags: [Foo, Bar]` will generate `services/FooService.ts` and `services/BarService.ts`.
+        - If there are no tags for the operation, the services will be created under the `default` tag. Operation with empty `tags: []` will generate `services/DefaultService.ts`.
+        - If `tags` are used as the base name, operation names will be generated based on the `operationId` from the
+          OpenAPI Operation, or from the path if `operationId` is not provided.
+          You can use `--operation-name-modifier` to customize the operation names.
 - **`--explicit-import-extensions`:** Include explicit `.js` extensions in all import statements. Ideal for projects using ECMAScript modules when TypeScript's _--moduleResolution_ is `node16` or `nodenext` _(optional)_.
 - **`--file-header <string>`:** Add a custom header to each generated file, useful for disabling linting rules or adding file
   comments _(optional)_.


### PR DESCRIPTION
1. Operation names now include all path parts and parameters by default.
2. The `/api/v{api-version}` part of the path is retained in the operation name.
3. The `--service-name-base` option now generates operation names with a new structure, allowing more flexibility and customization.

## Breaking Changes
- The structure of generated operation names has changed, potentially affecting existing code that relies on the previous naming convention.
- `/api/v{api-version}` is no longer automatically removed from the path when generating operation names.
- The `--service-name-base` option now influences the generated operation names.

## Examples
Here are examples of how operation names are now generated based on different `--service-name-base` options:

1. With `--service-name-base=endpoint[0]`:
   ```
   POST /v1/users/{id} → api.v1.postUsersId
   ```

2. With `--service-name-base=endpoint[1]`:
   ```
   GET /v1/users/{id} → api.users.getId
   ```

3. With `--service-name-base=endpoint[1]`:
   ```
   POST /v1/users/suspend → api.users.postSuspend
   ```

4. With `--service-name-base=endpoint[1]`:
   ```
   POST /v1/users/{id}/{key} → api.postIdKey
   ```

5. With `--service-name-base=tags`:
   ```
   POST /v1/users/{id}/{key} → api.<tag>.postV1UsersIdKey
   ```

## Motivation
This change improves the flexibility and customization of generated operation names by:
- Including all parts of the API path for more unique and descriptive names.
- Allowing users to control which parts of the path are included in the name through the `--service-name-base` option.
