### PR TITLE
feat(react-client): add support for multiple media types payload

### DIFF
--- a/.changeset/sweet-fans-arrive.md
+++ b/.changeset/sweet-fans-arrive.md
@@ -1,0 +1,7 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/tanstack-query-react-types': patch
+'@openapi-qraft/react': patch
+---
+
+Implemented support for requests with multiple media types. Now, if an endpoint accepts more than one media type (e.g., JSON and form-data), types will be generated to account for all possible cases, ensuring compatibility with both JSON and form-data input formats.

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,2 +1,3 @@
+export { getContentMediaType } from './lib/open-api/getContent.js';
 export { QraftCommand } from './lib/QraftCommand.js';
 export { type QraftCommandPlugin } from './lib/QraftCommandPlugin.js';

--- a/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
+++ b/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
@@ -15,7 +15,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "post",
         "name": "postEntitiesIdDocuments",
         "parameters": [
@@ -50,6 +49,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/entities/{entity_id}/documents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityOnboardingDocuments",
+              },
+            },
+          },
+        },
         "security": [
           {
             "userToken": [],
@@ -79,7 +87,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getApprovalPoliciesId",
         "parameters": [
@@ -127,6 +134,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "partnerToken": [],
@@ -145,7 +153,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
         "parameters": [
@@ -189,6 +196,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -207,7 +215,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "patch",
         "name": "patchApprovalPoliciesId",
         "parameters": [
@@ -251,6 +258,16 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalPolicyUpdate",
+              },
+            },
+          },
+          "required": true,
+        },
         "security": [
           {
             "HTTPBearer": [],
@@ -277,7 +294,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFiles",
         "parameters": [
@@ -316,6 +332,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -332,11 +349,28 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": "multipart/form-data",
         "method": "post",
         "name": "postFiles",
         "parameters": undefined,
         "path": "/files",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string",
+                  },
+                  "file_description": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -349,7 +383,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteFiles",
         "parameters": [
@@ -363,6 +396,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -375,7 +409,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFileList",
         "parameters": [
@@ -404,6 +437,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "path": "/files/list",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -436,7 +470,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "post",
         "name": "postEntitiesIdDocuments",
         "parameters": [
@@ -471,6 +504,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/entities/{entity_id}/documents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityOnboardingDocuments",
+              },
+            },
+          },
+        },
         "security": [
           {
             "userToken": [],
@@ -500,7 +542,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getApprovalPoliciesId",
         "parameters": [
@@ -548,6 +589,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "partnerToken": [],
@@ -566,7 +608,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
         "parameters": [
@@ -610,6 +651,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -628,7 +670,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "patch",
         "name": "patchApprovalPoliciesId",
         "parameters": [
@@ -672,6 +713,16 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalPolicyUpdate",
+              },
+            },
+          },
+          "required": true,
+        },
         "security": [
           {
             "HTTPBearer": [],
@@ -698,7 +749,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFiles",
         "parameters": [
@@ -737,6 +787,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -753,11 +804,28 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": "multipart/form-data",
         "method": "post",
         "name": "postFiles",
         "parameters": undefined,
         "path": "/files",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string",
+                  },
+                  "file_description": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -770,7 +838,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteFiles",
         "parameters": [
@@ -784,6 +851,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -796,7 +864,6 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFileList",
         "parameters": [
@@ -825,6 +892,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "path": "/files/list",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -857,7 +925,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "post",
         "name": "postEntitiesIdDocuments",
         "parameters": [
@@ -892,6 +959,15 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/entities/{entity_id}/documents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityOnboardingDocuments",
+              },
+            },
+          },
+        },
         "security": [
           {
             "userToken": [],
@@ -921,7 +997,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getApprovalPoliciesId",
         "parameters": [
@@ -969,6 +1044,7 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "partnerToken": [],
@@ -987,7 +1063,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
         "parameters": [
@@ -1031,6 +1106,7 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1049,7 +1125,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "patch",
         "name": "patchApprovalPoliciesId",
         "parameters": [
@@ -1093,6 +1168,16 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalPolicyUpdate",
+              },
+            },
+          },
+          "required": true,
+        },
         "security": [
           {
             "HTTPBearer": [],
@@ -1119,7 +1204,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFiles",
         "parameters": [
@@ -1158,6 +1242,7 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1174,11 +1259,28 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": "multipart/form-data",
         "method": "post",
         "name": "postFiles",
         "parameters": undefined,
         "path": "/files",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string",
+                  },
+                  "file_description": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -1191,7 +1293,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteFiles",
         "parameters": [
@@ -1205,6 +1306,7 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -1217,7 +1319,6 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFileList",
         "parameters": [
@@ -1246,6 +1347,7 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "path": "/files/list",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1277,7 +1379,6 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFiles",
         "parameters": [
@@ -1316,6 +1417,7 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1332,11 +1434,28 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": "multipart/form-data",
         "method": "post",
         "name": "postFiles",
         "parameters": undefined,
         "path": "/files",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string",
+                  },
+                  "file_description": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -1349,7 +1468,6 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteFiles",
         "parameters": [
@@ -1363,6 +1481,7 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -1375,7 +1494,6 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFileList",
         "parameters": [
@@ -1404,6 +1522,7 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           },
         ],
         "path": "/files/list",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1436,7 +1555,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "post",
         "name": "postEntitiesIdDocuments",
         "parameters": [
@@ -1471,6 +1589,15 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/entities/{entity_id}/documents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityOnboardingDocuments",
+              },
+            },
+          },
+        },
         "security": [
           {
             "userToken": [],
@@ -1500,7 +1627,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getApprovalPoliciesId",
         "parameters": [
@@ -1548,6 +1674,7 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "partnerToken": [],
@@ -1566,7 +1693,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
         "parameters": [
@@ -1610,6 +1736,7 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1628,7 +1755,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": "application/json",
         "method": "patch",
         "name": "patchApprovalPoliciesId",
         "parameters": [
@@ -1672,6 +1798,16 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/approval_policies/{approval_policy_id}",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalPolicyUpdate",
+              },
+            },
+          },
+          "required": true,
+        },
         "security": [
           {
             "HTTPBearer": [],
@@ -1698,7 +1834,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
           "422": "application/json",
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFiles",
         "parameters": [
@@ -1737,6 +1872,7 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],
@@ -1753,11 +1889,28 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": "multipart/form-data",
         "method": "post",
         "name": "postFiles",
         "parameters": undefined,
         "path": "/files",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string",
+                  },
+                  "file_description": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -1770,7 +1923,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "delete",
         "name": "deleteFiles",
         "parameters": [
@@ -1784,6 +1936,7 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/files",
+        "requestBody": undefined,
         "security": undefined,
         "success": {
           "200": "application/json",
@@ -1796,7 +1949,6 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "errors": {
           "default": "application/json",
         },
-        "mediaType": undefined,
         "method": "get",
         "name": "getFileList",
         "parameters": [
@@ -1825,6 +1977,7 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "path": "/files/list",
+        "requestBody": undefined,
         "security": [
           {
             "HTTPBearer": [],

--- a/packages/plugin/src/lib/open-api/getServices.ts
+++ b/packages/plugin/src/lib/open-api/getServices.ts
@@ -36,8 +36,8 @@ export type ServiceOperation = {
   description: string | undefined;
   summary: string | undefined;
   deprecated: boolean | undefined;
-  mediaType: string | undefined;
   errors: Record<string, string | undefined>;
+  requestBody: OpenAPISchemaType['paths'][string]['post']['requestBody'];
   success: Record<string, string | undefined>;
   parameters:
     | {
@@ -155,9 +155,7 @@ export const getServices = (
             !methodOperation.parameters.length
               ? undefined
               : methodOperation.parameters,
-          mediaType: methodOperation.requestBody?.content
-            ? getContentMediaType(methodOperation.requestBody.content)
-            : undefined,
+          requestBody: methodOperation.requestBody,
           success: success,
           security: methodOperation.security,
         });

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint",
     "clean": "rimraf dist/",
     "codegen": "openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript ../test-fixtures/openapi.json -rm -o src/tests/fixtures/api --openapi-types-file-name openapi.ts --explicit-import-extensions --filter-services '/approval_policies/**,/entities/**,/files/**,!/internal/**' --operation-predefined-parameters '/approval_policies/{approval_policy_id}/**:header.x-monite-entity-id' '/entities/{entity_id}/documents:header.x-monite-version' --operation-name-modifier '/files/list:[a-zA-Z]+List ==> findAll' && yarn _prettify-api",
+    "codegen2": "openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript http://localhost:3000/api/doc -rm -o src/tests/fixtures/api --openapi-types-file-name openapi.ts --explicit-import-extensions && yarn _prettify-api",
     "_prettify-api": "prettier --write src/tests/fixtures/api/**/*.ts"
   },
   "sideEffects": false,

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -78,6 +78,11 @@
       "require": "./dist/cjs/qraftPredefinedParametersRequestFn.cjs",
       "types": "./dist/types/qraftPredefinedParametersRequestFn.d.ts"
     },
+    "./unstable__responseUtils": {
+      "import": "./dist/esm/unstable__responseUtils.js",
+      "require": "./dist/cjs/unstable__responseUtils.cjs",
+      "types": "./dist/types/unstable__responseUtils.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {

--- a/packages/react-client/rollup.config.mjs
+++ b/packages/react-client/rollup.config.mjs
@@ -13,6 +13,7 @@ const config = [
   rollupConfig(moduleDist, {
     input: 'src/qraftPredefinedParametersRequestFn.ts',
   }),
+  rollupConfig(moduleDist, { input: 'src/unstable__responseUtils.ts' }),
 ];
 
 export default config;

--- a/packages/react-client/src/lib/responseUtils.ts
+++ b/packages/react-client/src/lib/responseUtils.ts
@@ -1,0 +1,77 @@
+import type { RequestFnResponse } from '@openapi-qraft/tanstack-query-react-types';
+
+/**
+ * Processes the response from the server.
+ * @beta
+ */
+export async function processResponse<TData, TError>(
+  response: Response
+): Promise<RequestFnResponse<TData, TError>> {
+  if (response.status === 204 || response.headers.get('Content-Length') === '0')
+    return (
+      response.ok ? { data: {}, response } : { error: {}, response }
+    ) as RequestFnResponse<TData, TError>;
+
+  if (isJsonResponse(response)) {
+    // clone response before parsing every time to allow multiple reads
+    const jsonResponse = response.clone().json();
+    return resolveResponse(
+      response,
+      response.ok ? jsonResponse : Promise.reject(await jsonResponse)
+    );
+  }
+
+  const jsonResponse = new Promise<TData>((resolve, reject) =>
+    // attempt to parse JSON for successful responses, otherwise fail
+    response.clone().text().then(JSON.parse).then(resolve, reject)
+  );
+
+  return resolveResponse(
+    response,
+    response.ok ? jsonResponse : Promise.reject(await jsonResponse)
+  );
+}
+
+/**
+ * Resolves the response from the server.
+ * @beta
+ */
+export function resolveResponse<TData, TError>(
+  error: Error
+): Promise<RequestFnResponse<TData, TError>>;
+export function resolveResponse<TData, TError>(
+  responseToReturn: Response,
+  responsePromise: Promise<TData>
+): Promise<RequestFnResponse<TData, TError>>;
+export function resolveResponse<TData, TError>(
+  responseToReturn: Response | Error,
+  responsePromise?: Promise<TData>
+): Promise<RequestFnResponse<TData, TError>> {
+  if (!responsePromise)
+    return Promise.reject({
+      error: responseToReturn,
+      response: undefined,
+      data: undefined,
+    });
+
+  return responsePromise
+    .then(
+      (data) =>
+        ({ data, response: responseToReturn }) as RequestFnResponse<
+          TData,
+          TError
+        >
+    )
+    .catch(
+      (error) =>
+        ({ error, response: responseToReturn }) as RequestFnResponse<
+          TData,
+          TError
+        >
+    );
+}
+
+function isJsonResponse(response: Response) {
+  const contentType = response.headers.get('Content-Type')?.toLowerCase();
+  return contentType?.includes('/json') || contentType?.includes('+json');
+}

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -1309,6 +1309,8 @@ describe('Qraft uses Mutations', () => {
       () =>
         qraft.files.postFiles.useMutation(undefined, {
           onMutate: (variables) => {
+            if (variables?.body instanceof FormData)
+              throw new Error('FormData');
             // check types inference when parameters are not specified
             variables?.body?.file satisfies Blob | undefined;
             variables?.body?.file_description satisfies string | undefined;
@@ -1347,6 +1349,7 @@ describe('Qraft uses Mutations', () => {
           {},
           {
             onMutate: (variables) => {
+              if (variables instanceof FormData) throw new Error('FormData');
               // check types inference when parameters are specified
               variables?.file satisfies Blob | undefined;
               variables?.file_description satisfies string | undefined;

--- a/packages/react-client/src/unstable__responseUtils.ts
+++ b/packages/react-client/src/unstable__responseUtils.ts
@@ -1,0 +1,1 @@
+export { resolveResponse, processResponse } from './lib/responseUtils.js';

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -832,7 +832,9 @@ export const approvalPoliciesService: {
         schema: {
             method: "patch";
             url: "/approval_policies/{approval_policy_id}";
-            mediaType: "application/json";
+            mediaType: [
+                "application/json"
+            ];
             security: [
                 "HTTPBearer"
             ];
@@ -857,7 +859,7 @@ export const approvalPoliciesService: {
         schema: {
             method: "patch",
             url: "/approval_policies/{approval_policy_id}",
-            mediaType: "application/json",
+            mediaType: ["application/json"],
             security: ["HTTPBearer"]
         }
     }
@@ -886,7 +888,9 @@ type DeleteApprovalPoliciesIdBody = undefined;
 type PatchApprovalPoliciesIdSchema = {
     method: "patch";
     url: "/approval_policies/{approval_policy_id}";
-    mediaType: "application/json";
+    mediaType: [
+        "application/json"
+    ];
     security: [
         "HTTPBearer"
     ];

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -962,7 +962,9 @@ export const filesService: {
         schema: {
             method: "post";
             url: "/files";
-            mediaType: "multipart/form-data";
+            mediaType: [
+                "multipart/form-data"
+            ];
         };
     };
     /** @summary Delete all files */
@@ -997,7 +999,7 @@ export const filesService: {
         schema: {
             method: "post",
             url: "/files",
-            mediaType: "multipart/form-data"
+            mediaType: ["multipart/form-data"]
         }
     },
     deleteFiles: {
@@ -1027,12 +1029,14 @@ type GetFilesError = paths["/files"]["get"]["responses"]["405"]["content"]["appl
 type PostFilesSchema = {
     method: "post";
     url: "/files";
-    mediaType: "multipart/form-data";
+    mediaType: [
+        "multipart/form-data"
+    ];
 };
 type PostFilesParameters = {};
 type PostFilesData = paths["/files"]["post"]["responses"]["200"]["content"]["application/json"];
 type PostFilesError = paths["/files"]["post"]["responses"]["default"]["content"]["application/json"];
-type PostFilesBody = NonNullable<paths["/files"]["post"]["requestBody"]>["content"]["multipart/form-data"];
+type PostFilesBody = NonNullable<paths["/files"]["post"]["requestBody"]>["content"]["multipart/form-data"] | FormData;
 type DeleteFilesSchema = {
     method: "delete";
     url: "/files";

--- a/packages/tanstack-query-react-types/src/shared/MutationFilters.ts
+++ b/packages/tanstack-query-react-types/src/shared/MutationFilters.ts
@@ -69,8 +69,9 @@ export interface MutationFiltersByMutationKey<
   parameters?: never;
 }
 
-export type MutationVariables<TBody, TParams> =
-  AreAllOptional<TBody> extends true
+export type MutationVariables<TBody, TParams> = TBody extends FormData
+  ? { body: TBody } & NonNullableObject<TParams>
+  : AreAllOptional<TBody> extends true
     ? AreAllOptional<TParams> extends true
       ? ({ body?: TBody } & NonNullableObject<TParams>) | void
       : { body?: TBody } & NonNullableObject<TParams>

--- a/packages/tanstack-query-react-types/src/shared/RequestFn.ts
+++ b/packages/tanstack-query-react-types/src/shared/RequestFn.ts
@@ -41,7 +41,7 @@ export interface OperationSchema {
    * Media type of the request body
    * @example application/json
    */
-  readonly mediaType?: string;
+  readonly mediaType?: string[];
 
   readonly security?: string[];
 }
@@ -118,8 +118,13 @@ export interface RequestFnOptions {
 
 type BodySerializer = (
   schema: OperationSchema,
-  info: RequestFnInfo
-) => string | FormData | Blob | undefined;
+  body: RequestFnInfo['body']
+) =>
+  | {
+      body: string | FormData | Blob;
+      headers: HeadersOptions;
+    }
+  | undefined;
 
 type UrlSerializer = (schema: OperationSchema, info: RequestFnInfo) => string;
 


### PR DESCRIPTION
- If an endpoint is configured to accept different types of input, such as `application/json` or `multipart/form-data`, the generated types will now include representations for all specified formats.

### Changes
- Added support for JSON and `*/form-data` in the type generation process.