### PR TITLE
feat(react-client): simplify `processResponse` logic for handling `text/plain` content

### DIFF
--- a/.changeset/neat-kangaroos-rhyme.md
+++ b/.changeset/neat-kangaroos-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': minor
+---
+
+Responses with the `text/plain` content type are now always processed as plain text, without attempting to fallback to `JSON.parse`.


### PR DESCRIPTION
Removed the fallback to `JSON.parse`, ensuring more predictable behavior when dealing with plain text responses.