### PR TITLE
feat(plugin): add support for operation parameters using `$ref` from OpenAPI `components/parameters`

### DIFF
--- a/.changeset/popular-doors-yell.md
+++ b/.changeset/popular-doors-yell.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/plugin': patch
+---
+
+Added support for operation parameters referencing `$ref` from OpenAPI `components/parameters`.

--- a/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
@@ -158,7 +158,11 @@ export interface components {
         };
     };
     responses: never;
-    parameters: never;
+    parameters: {
+        IdIn: string[];
+        /** @example 2023-06-04 */
+        XMoniteVersion: string;
+    };
     requestBodies: never;
     headers: never;
     pathItems: never;
@@ -582,11 +586,11 @@ export interface operations {
     get_file_list: {
         parameters: {
             query?: {
-                id__in?: string[];
+                id__in?: components["parameters"]["IdIn"];
             };
             header?: {
                 /** @example 2023-06-04 */
-                "x-monite-version"?: string;
+                "x-monite-version"?: components["parameters"]["XMoniteVersion"];
             };
             path?: never;
             cookie?: never;

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-enum-exports.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-enum-exports.ts.snapshot.ts
@@ -90,7 +90,11 @@ export interface components {
         };
     };
     responses: never;
-    parameters: never;
+    parameters: {
+        IdIn: string[];
+        /** @example 2023-06-04 */
+        XMoniteVersion: string;
+    };
     requestBodies: never;
     headers: never;
     pathItems: never;

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-exports.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-exports.ts.snapshot.ts
@@ -90,7 +90,11 @@ export interface components {
         };
     };
     responses: never;
-    parameters: never;
+    parameters: {
+        IdIn: string[];
+        /** @example 2023-06-04 */
+        XMoniteVersion: string;
+    };
     requestBodies: never;
     headers: never;
     pathItems: never;

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
@@ -110,7 +110,11 @@ export interface components {
         };
     };
     responses: never;
-    parameters: never;
+    parameters: {
+        IdIn: string[];
+        /** @example 2023-06-04 */
+        XMoniteVersion: string;
+    };
     requestBodies: never;
     headers: never;
     pathItems: never;
@@ -261,11 +265,11 @@ export interface operations {
     get_file_list: {
         parameters: {
             query?: {
-                id__in?: string[];
+                id__in?: components["parameters"]["IdIn"];
             };
             header?: {
                 /** @example 2023-06-04 */
-                "x-monite-version"?: string;
+                "x-monite-version"?: components["parameters"]["XMoniteVersion"];
             };
             path?: never;
             cookie?: never;

--- a/packages/plugin/src/lib/open-api/OpenAPISchemaType.ts
+++ b/packages/plugin/src/lib/open-api/OpenAPISchemaType.ts
@@ -34,4 +34,7 @@ export type OpenAPISchemaType = {
       };
     };
   };
+  components: {
+    parameters: Record<string, any> | undefined;
+  };
 };

--- a/packages/plugin/src/lib/open-api/getServices.ts
+++ b/packages/plugin/src/lib/open-api/getServices.ts
@@ -7,6 +7,7 @@ import {
   ServiceBaseNameByEndpointOption,
 } from './getServiceNamesByOperationEndpoint.js';
 import { getServiceNamesByOperationTags } from './getServiceNamesByOperationTags.js';
+import { replaceRefParametersWithComponent } from './replaceRefParametersWithComponent.js';
 
 export type ServiceBaseName = ServiceBaseNameByEndpointOption | 'tags';
 
@@ -65,6 +66,7 @@ export const getServices = (
   }: ServiceOutputOptions = {}
 ) => {
   const paths = openApiJson.paths;
+  const parametersComponents = openApiJson.components.parameters ?? {};
 
   const services = new Map<string, Service>();
 
@@ -150,11 +152,11 @@ export const getServices = (
           description: methodOperation.description,
           summary: methodOperation.summary,
           deprecated: methodOperation.deprecated,
-          parameters:
-            Array.isArray(methodOperation.parameters) &&
-            !methodOperation.parameters.length
-              ? undefined
-              : methodOperation.parameters,
+          parameters: replaceRefParametersWithComponent(
+            // @ts-expect-error the issue with custom OpenAPISchemaType
+            methodOperation.parameters,
+            parametersComponents
+          ),
           requestBody: methodOperation.requestBody,
           success: success,
           security: methodOperation.security,

--- a/packages/plugin/src/lib/open-api/replaceRefParametersWithComponent.ts
+++ b/packages/plugin/src/lib/open-api/replaceRefParametersWithComponent.ts
@@ -1,0 +1,40 @@
+import type { OpenAPISchemaType } from './OpenAPISchemaType.js';
+import { ParameterObject } from 'openapi-typescript';
+import { ReferenceObject } from 'openapi-typescript/src/types.js';
+
+export function replaceRefParametersWithComponent(
+  parameters: ParameterObject | ReferenceObject | undefined,
+  parametersComponents: OpenAPISchemaType['components']['parameters']
+) {
+  if (!Array.isArray(parameters)) return undefined;
+
+  const definedParameters = parameters
+    .map((parameter) => {
+      if (parameter.$ref)
+        return getParametersComponentByRef(
+          parameter.$ref,
+          parametersComponents
+        );
+      return parameter;
+    })
+    .filter(Boolean);
+
+  if (!definedParameters.length) return undefined;
+
+  return definedParameters;
+}
+
+/**
+ * Get the operation from the $ref
+ * @param $ref Example: `#/components/parameters/Export`
+ * @param parameters
+ */
+function getParametersComponentByRef(
+  $ref: string,
+  parameters: OpenAPISchemaType['components']['parameters']
+) {
+  const refPath = $ref.split('/').slice(1);
+  if (refPath[1] === 'parameters') {
+    return parameters?.[refPath[2]];
+  }
+}

--- a/packages/plugin/src/lib/predefineSchemaParameters.test.ts
+++ b/packages/plugin/src/lib/predefineSchemaParameters.test.ts
@@ -1,8 +1,8 @@
+import type { ParameterObject, ReferenceObject } from 'openapi-typescript';
 import openAPI from '@openapi-qraft/test-fixtures/openapi.json' with { type: 'json' };
 import { describe, expect, it } from 'vitest';
 import {
   assertIsOperationObject,
-  assertIsParameterObjects,
   createPredefinedParametersGlobs,
   parseOperationPredefinedParametersOption,
   predefineSchemaParameters,
@@ -508,3 +508,15 @@ describe('predefineSchemaParameters utils', () => {
     });
   });
 });
+
+function assertIsParameterObjects(
+  parameterObjects: Array<ParameterObject | ReferenceObject>
+): asserts parameterObjects is Array<ParameterObject> {
+  parameterObjects.forEach((parameterObject) => {
+    if ('$ref' in parameterObject) {
+      throw new Error(
+        `Expected a ParameterObject, but got a ReferenceObject: ${parameterObject}`
+      );
+    }
+  });
+}

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -11,7 +11,6 @@
     "lint": "eslint",
     "clean": "rimraf dist/",
     "codegen": "openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript ../test-fixtures/openapi.json -rm -o src/tests/fixtures/api --openapi-types-file-name openapi.ts --explicit-import-extensions --filter-services '/approval_policies/**,/entities/**,/files/**,!/internal/**' --operation-predefined-parameters '/approval_policies/{approval_policy_id}/**:header.x-monite-entity-id' '/entities/{entity_id}/documents:header.x-monite-version' --operation-name-modifier '/files/list:[a-zA-Z]+List ==> findAll' && yarn _prettify-api",
-    "codegen2": "openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript http://localhost:3000/api/doc -rm -o src/tests/fixtures/api --openapi-types-file-name openapi.ts --explicit-import-extensions && yarn _prettify-api",
     "_prettify-api": "prettier --write src/tests/fixtures/api/**/*.ts"
   },
   "sideEffects": false,

--- a/packages/test-fixtures/openapi.json
+++ b/packages/test-fixtures/openapi.json
@@ -618,23 +618,8 @@
         "summary": "Get a file list",
         "operationId": "get_file_list",
         "parameters": [
-          {
-            "required": false,
-            "schema": { "type": "string", "format": "date" },
-            "example": "2023-06-04",
-            "name": "x-monite-version",
-            "in": "header"
-          },
-          {
-            "required": false,
-            "schema": {
-              "items": { "type": "string", "format": "uuid" },
-              "type": "array",
-              "maxItems": 100
-            },
-            "name": "id__in",
-            "in": "query"
-          }
+          { "$ref": "#/components/parameters/XMoniteVersion" },
+          { "$ref": "#/components/parameters/IdIn" }
         ],
         "responses": {
           "200": {
@@ -805,6 +790,25 @@
         "additionalProperties": false,
         "type": "object",
         "required": ["id", "file_type", "name", "url"]
+      }
+    },
+    "parameters": {
+      "IdIn": {
+        "in": "query",
+        "required": false,
+        "schema": {
+          "items": { "type": "string", "format": "uuid" },
+          "type": "array",
+          "maxItems": 100
+        },
+        "name": "id__in"
+      },
+      "XMoniteVersion": {
+        "required": false,
+        "schema": { "type": "string", "format": "date" },
+        "example": "2023-06-04",
+        "name": "x-monite-version",
+        "in": "header"
       }
     }
   }


### PR DESCRIPTION
Added support for operation parameters using `$ref` from OpenAPI `components/parameters`.