### PR TITLE
feat: operations without args when possible

### DIFF
--- a/.changeset/two-timers-jam.md
+++ b/.changeset/two-timers-jam.md
@@ -1,0 +1,6 @@
+---
+'@openapi-qraft/tanstack-query-react-types': patch
+'@openapi-qraft/openapi-typescript-plugin': patch
+---
+
+Added support for `void` and `undefined` arguments in mutation operations and `setQueryData`.

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -2628,6 +2628,11 @@ describe('Qraft uses "setQueryData(...)"', () => {
     });
   });
 
+  it('supports getQueryData without parameters when all parameters are optional', () => {
+    const { qraft } = createClient();
+    qraft.files.findAll.getQueryData(); // should not emit type error
+  });
+
   it('emits type error if parameters is not provided', async () => {
     const { qraft } = createClient();
 

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -2782,6 +2782,20 @@ describe('Qraft uses getQueriesData', () => {
     ).toEqual([[qraft.files.getFiles.getQueryKey(parameters), parameters]]);
   });
 
+  it('uses setQueryData with undefined parameters when all parameters are optional', () => {
+    const { qraft } = createClient();
+    qraft.files.findAll.setQueryData(undefined, {
+      data: [
+        {
+          id: '1',
+          name: 'file1',
+          url: 'https://example.com',
+          file_type: 'pdf',
+        },
+      ],
+    }); // should not emit type error
+  });
+
   it('uses getQueriesData Infinite Queries', async () => {
     const { qraft } = createClient();
 

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -2156,7 +2156,7 @@ describe('Qraft uses Operation Mutation Function', () => {
     });
   });
 
-  it('supports Operation Mutation', async () => {
+  it('supports Operation Mutation with parameters and body', async () => {
     const { qraft } = createClient();
 
     const { data, error } = await qraft.entities.postEntitiesIdDocuments({
@@ -2203,6 +2203,11 @@ describe('Qraft uses Operation Mutation Function', () => {
         verification_document_front: 'front',
       },
     });
+  });
+
+  it('handles mutation operation without body or parameters when optional or undefined', async () => {
+    const { qraft } = createClient();
+    void qraft.files.deleteFiles();
   });
 
   it('supports Operation Mutation with `requestFn` and `baseUrl`', async () => {

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -168,7 +168,7 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        setQueryData(parameters: GetApprovalPoliciesIdParameters | ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, updater: Updater<NoInfer<GetApprovalPoliciesIdData> | undefined, NoInfer<GetApprovalPoliciesIdData> | undefined>, options?: SetDataOptions): GetApprovalPoliciesIdData | undefined;
+        setQueryData(parameters: (GetApprovalPoliciesIdParameters) | ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, updater: Updater<NoInfer<GetApprovalPoliciesIdData> | undefined, NoInfer<GetApprovalPoliciesIdData> | undefined>, options?: SetDataOptions): GetApprovalPoliciesIdData | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
@@ -570,7 +570,7 @@ export interface ApprovalPoliciesService {
          * @summary Delete an approval policy
          * @description Delete an existing approval policy.
          */
-        <TOptions extends ServiceOperationMutationFnOptions<DeleteApprovalPoliciesIdBody, DeleteApprovalPoliciesIdParameters>>(options: TOptions, client?: (schema: DeleteApprovalPoliciesIdSchema, options: TOptions) => Promise<RequestFnResponse<DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdError>>): Promise<RequestFnResponse<DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdError>>;
+        (options: ServiceOperationMutationFnOptions<DeleteApprovalPoliciesIdBody, DeleteApprovalPoliciesIdParameters>, client?: (schema: DeleteApprovalPoliciesIdSchema, options: ServiceOperationMutationFnOptions<DeleteApprovalPoliciesIdBody, DeleteApprovalPoliciesIdParameters>) => Promise<RequestFnResponse<DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdError>>): Promise<RequestFnResponse<DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdError>>;
         /**
          * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
          *
@@ -747,7 +747,7 @@ export interface ApprovalPoliciesService {
          * @summary Update an approval policy
          * @description Update an existing approval policy.
          */
-        <TOptions extends ServiceOperationMutationFnOptions<PatchApprovalPoliciesIdBody, PatchApprovalPoliciesIdParameters>>(options: TOptions, client?: (schema: PatchApprovalPoliciesIdSchema, options: TOptions) => Promise<RequestFnResponse<PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdError>>): Promise<RequestFnResponse<PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdError>>;
+        (options: ServiceOperationMutationFnOptions<PatchApprovalPoliciesIdBody, PatchApprovalPoliciesIdParameters>, client?: (schema: PatchApprovalPoliciesIdSchema, options: ServiceOperationMutationFnOptions<PatchApprovalPoliciesIdBody, PatchApprovalPoliciesIdParameters>) => Promise<RequestFnResponse<PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdError>>): Promise<RequestFnResponse<PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdError>>;
         /**
          * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
          *

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -95,7 +95,7 @@ export interface FilesService {
         /** @summary Get a files by ID */
         setQueriesData<TInfinite extends boolean = false>(filters: QueryFiltersByParameters<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError> | QueryFiltersByQueryKey<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError>, updater: Updater<NoInfer<GetFilesData> | undefined, NoInfer<GetFilesData> | undefined>, options?: SetDataOptions): Array<GetFilesData | undefined>;
         /** @summary Get a files by ID */
-        setQueryData(parameters: GetFilesParameters | ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>, updater: Updater<NoInfer<GetFilesData> | undefined, NoInfer<GetFilesData> | undefined>, options?: SetDataOptions): GetFilesData | undefined;
+        setQueryData(parameters: (GetFilesParameters) | ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>, updater: Updater<NoInfer<GetFilesData> | undefined, NoInfer<GetFilesData> | undefined>, options?: SetDataOptions): GetFilesData | undefined;
         /** @summary Get a files by ID */
         getInfiniteQueryKey(parameters: GetFilesParameters): ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>;
         /**
@@ -385,7 +385,7 @@ export interface FilesService {
         /** @summary Upload a files by ID */
         isMutating<TContext>(filters?: MutationFiltersByParameters<PostFilesBody, PostFilesData, PostFilesParameters, PostFilesError, TContext> | MutationFiltersByMutationKey<PostFilesSchema, PostFilesBody, PostFilesData, PostFilesParameters, PostFilesError, TContext>): number;
         /** @summary Upload a files by ID */
-        <TOptions extends ServiceOperationMutationFnOptions<PostFilesBody, PostFilesParameters>>(options: TOptions, client?: (schema: PostFilesSchema, options: TOptions) => Promise<RequestFnResponse<PostFilesData, PostFilesError>>): Promise<RequestFnResponse<PostFilesData, PostFilesError>>;
+        (options: ServiceOperationMutationFnOptions<PostFilesBody, PostFilesParameters>, client?: (schema: PostFilesSchema, options: ServiceOperationMutationFnOptions<PostFilesBody, PostFilesParameters>) => Promise<RequestFnResponse<PostFilesData, PostFilesError>>): Promise<RequestFnResponse<PostFilesData, PostFilesError>>;
         /**
          * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
          *
@@ -502,7 +502,7 @@ export interface FilesService {
         /** @summary Delete all files */
         isMutating<TContext>(filters?: MutationFiltersByParameters<DeleteFilesBody, DeleteFilesData, DeleteFilesParameters, DeleteFilesError, TContext> | MutationFiltersByMutationKey<DeleteFilesSchema, DeleteFilesBody, DeleteFilesData, DeleteFilesParameters, DeleteFilesError, TContext>): number;
         /** @summary Delete all files */
-        <TOptions extends ServiceOperationMutationFnOptions<DeleteFilesBody, DeleteFilesParameters>>(options: TOptions, client?: (schema: DeleteFilesSchema, options: TOptions) => Promise<RequestFnResponse<DeleteFilesData, DeleteFilesError>>): Promise<RequestFnResponse<DeleteFilesData, DeleteFilesError>>;
+        (options: ServiceOperationMutationFnOptions<DeleteFilesBody, DeleteFilesParameters>, client?: (schema: DeleteFilesSchema, options: ServiceOperationMutationFnOptions<DeleteFilesBody, DeleteFilesParameters>) => Promise<RequestFnResponse<DeleteFilesData, DeleteFilesError>>): Promise<RequestFnResponse<DeleteFilesData, DeleteFilesError>>;
         /**
          * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
          *
@@ -703,7 +703,7 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        setQueryData(parameters: GetFileListParameters | ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>, updater: Updater<NoInfer<GetFileListData> | undefined, NoInfer<GetFileListData> | undefined>, options?: SetDataOptions): GetFileListData | undefined;
+        setQueryData(parameters: (GetFileListParameters | undefined) | ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>, updater: Updater<NoInfer<GetFileListData> | undefined, NoInfer<GetFileListData> | undefined>, options?: SetDataOptions): GetFileListData | undefined;
         /**
          * @deprecated
          * @summary Get a file list

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -765,13 +765,10 @@ function reduceAreAllOptionalConditionalTParamsType<T extends ts.Node>(
             );
           })
         ) {
-          if (
-            !operation.parameters?.length ||
-            operation.parameters.every((parameter) => !parameter.required)
-          ) {
-            return node.trueType;
-          } else {
+          if (operation.parameters?.some((parameter) => parameter.required)) {
             return node.falseType;
+          } else {
+            return node.trueType;
           }
         }
         return ts.visitEachChild(node, visit, context);

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationMutationFn.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationMutationFn.ts
@@ -10,11 +10,11 @@ export interface ServiceOperationMutationFn<
   TParams,
   TError,
 > {
-  <TOptions extends ServiceOperationMutationFnOptions<TBody, TParams>>(
-    options: TOptions,
+  (
+    options: ServiceOperationMutationFnOptions<TBody, TParams>,
     client?: (
       schema: TSchema,
-      options: TOptions
+      options: ServiceOperationMutationFnOptions<TBody, TParams>
     ) => Promise<RequestFnResponse<TMutationData, TError>>
   ): Promise<RequestFnResponse<TMutationData, TError>>;
 }

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationSetQueryData.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationSetQueryData.ts
@@ -1,13 +1,18 @@
-import type { ServiceOperationQueryKey } from '@openapi-qraft/tanstack-query-react-types';
+import type {
+  AreAllOptional,
+  ServiceOperationQueryKey,
+} from '@openapi-qraft/tanstack-query-react-types';
 import type { NoInfer, SetDataOptions, Updater } from '@tanstack/query-core';
 
 export interface ServiceOperationSetQueryData<
   TSchema extends { url: string; method: string },
   TQueryFnData,
-  TParams = {},
+  TParams,
 > {
   setQueryData(
-    parameters: TParams | ServiceOperationQueryKey<TSchema, TParams>,
+    parameters:
+      | (AreAllOptional<TParams> extends true ? TParams | undefined : TParams)
+      | ServiceOperationQueryKey<TSchema, TParams>,
     updater: Updater<
       NoInfer<TQueryFnData> | undefined,
       NoInfer<TQueryFnData> | undefined

--- a/packages/ts-factory-code-generator/package.json
+++ b/packages/ts-factory-code-generator/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "build": "yarn exec ./generateFactoryCodeGenerator.mjs && tsc --build",
-    "generate-ts-factory": "tsx generateTsFactoryCLI.ts -- --source-file /Users/radist/WebstormProjects/qraft/packages/react-client/src/service-operation/ServiceOperationUseQuery.ts"
+    "build": "yarn exec ./generateFactoryCodeGenerator.mjs && tsc --build"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "cache": true,
       "dependsOn": ["write-package-version-file", "codegen", "^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", "tsFactoryCodeGenerator.ts"]
     },
     "test": {
       "cache": true,


### PR DESCRIPTION
Added support for operations without arguments when possible, improving flexibility and removing unnecessary parameters. Key changes include:

**Support for `void` argument**:
  - Added support for passing `void` to mutation operations.
  - Added support for the `undefined` argument in the `setQueryData` method.