### PR TITLE
feat: export from schema just common types

### DIFF
--- a/.changeset/tidy-knives-travel.md
+++ b/.changeset/tidy-knives-travel.md
@@ -1,0 +1,6 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': major
+'@openapi-qraft/cli': major
+---
+
+Changed the exports from the schema file to include only the essential types: `$defs`, `paths`, `components`, `operations`, `webhooks`. This adjustment improves the development experience by preventing the export of all schema types, which could result in an excessive number of exported types, complicating development and reducing clarity.

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions-d-ts-imports/index.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions-d-ts-imports/index.ts.snapshot.ts
@@ -3,7 +3,7 @@
  * Do not make direct changes to the file.
  */
 
-export type * from "./../openapi.d.ts";
+export type { $defs, paths, components, operations, webhooks } from "./../openapi.d.ts";
 export { services } from "./services/index.js";
 export type { Services } from "./services/index.js";
 export { createAPIClient } from "./create-api-client.js";

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/index.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/index.ts.snapshot.ts
@@ -3,7 +3,7 @@
  * Do not make direct changes to the file.
  */
 
-export * from "./../openapi.js";
+export type { $defs, paths, components, operations, webhooks } from "./../openapi.js";
 export { services } from "./services/index.js";
 export type { Services } from "./services/index.js";
 export { createAPIClient } from "./create-api-client.js";

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/openapi-types-import-path-d-ts/index.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/openapi-types-import-path-d-ts/index.ts.snapshot.ts
@@ -3,7 +3,7 @@
  * Do not make direct changes to the file.
  */
 
-export type * from "./../openapi.d.ts";
+export type { $defs, paths, components, operations, webhooks } from "./../openapi.d.ts";
 export { services } from "./services/index";
 export type { Services } from "./services/index";
 export { createAPIClient } from "./create-api-client";

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/openapi-types-import-path-ts/index.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/openapi-types-import-path-ts/index.ts.snapshot.ts
@@ -3,7 +3,7 @@
  * Do not make direct changes to the file.
  */
 
-export * from "./../openapi.ts";
+export type { $defs, paths, components, operations, webhooks } from "./../openapi.ts";
 export { services } from "./services/index";
 export type { Services } from "./services/index";
 export { createAPIClient } from "./create-api-client";

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getIndexFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getIndexFactory.ts
@@ -18,8 +18,17 @@ export const getIndexFactory = ({
       ? [
           factory.createExportDeclaration(
             undefined,
-            openapiTypesImportPath.endsWith('.d.ts'),
-            undefined,
+            true,
+            factory.createNamedExports(
+              ['$defs', 'paths', 'components', 'operations', 'webhooks'].map(
+                (name) =>
+                  factory.createExportSpecifier(
+                    false,
+                    undefined,
+                    factory.createIdentifier(name)
+                  )
+              )
+            ),
             factory.createStringLiteral(
               maybeResolveImport({ openapiTypesImportPath, servicesDirName })
             ),


### PR DESCRIPTION
Changed the exports from the schema file to include only the essential types: `$defs`, `paths`, `components`, `operations`, `webhooks`. This adjustment improves the development experience by preventing the export of all schema types, which could result in an excessive number of exported types, complicating development and reducing clarity.

This change ensures that only the necessary components are exported, avoiding the clutter that would otherwise arise when using the `--explicit-component-exports` option.