### PR TITLE
feat: add support for `--explicit-import-extensions .ts`

### DIFF
--- a/.changeset/famous-turtles-invent.md
+++ b/.changeset/famous-turtles-invent.md
@@ -1,0 +1,6 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/cli': patch
+---
+
+Enhanced the `--explicit-import-extensions` option to support `.ts` in addition to `.js`, making it easier for projects using TypeScript to explicitly specify import extensions.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,7 @@ Options:
   --service-name-base <endpoint[<index>] | tags>   Use OpenAPI Operation `endpoint[<index>]` path part (e.g.: "/0/1/2") or `tags` as the base name of the service. (default: "endpoint[0]")
   --file-header <string>                           Header to be added to the generated file (eg: /* eslint-disable */)
   --openapi-types-import-path <path>               Path to schema types file (.d.ts), eg: "../schema.d.ts"
-  --explicit-import-extensions                     All import statements will include explicit `.js` extensions. Ideal for projects using ECMAScript modules.
+  --explicit-import-extensions [extension]         All import statements will contain an explicit file extension. Ideal for projects using ECMAScript modules. (choices: ".js", ".ts", preset: ".js")
   --export-openapi-types [bool]                    Export the OpenAPI schema types from the generated `./index.ts` file (default: true)
   --operation-generics-import-path <path>          Path to operation generics file (default: "@openapi-qraft/react")
   --openapi-types-file-name <path>                 OpenAPI Schema types file name, eg: "schema.d.ts" (default: "schema.ts")
@@ -145,7 +145,8 @@ npx openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript http
     - `--service-name-base tags` will generate services based on the OpenAPI Operation tags instead of the endpoint.
       - If multiple tags are present for the operation, similar services will be created for each tag. Operation with `tags: [Foo, Bar]` will generate `services/FooService.ts` and `services/BarService.ts`.
       - If there are no tags for the operation, the services will be created under the `default` tag. Operation with empty `tags: []` will generate `services/DefaultService.ts`.
-- **`--explicit-import-extensions`:** Include explicit `.js` extensions in all import statements. Ideal for projects using ECMAScript modules when TypeScript's _--moduleResolution_ is `node16` or `nodenext` _(optional)_.
+- **`--explicit-import-extensions [extension]`**: All import statements will contain an explicit file extension. Ideal for projects using ECMAScript modules
+  when TypeScript's _--moduleResolution_ is `node16` or `nodenext`. Choices: `.js`, `.ts`, preset: `.js`. _(optional)_
 - **`--file-header <string>`:** Add a custom header to each generated file, useful for disabling linting rules or adding file
   comments _(optional)_.
   - Example: `--file-header '/* eslint-disable */'`

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions-d-ts-imports/index.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions-d-ts-imports/index.ts.snapshot.ts
@@ -4,6 +4,6 @@
  */
 
 export type { $defs, paths, components, operations, webhooks } from "./../openapi.d.ts";
-export { services } from "./services/index.js";
-export type { Services } from "./services/index.js";
-export { createAPIClient } from "./create-api-client.js";
+export { services } from "./services/index.ts";
+export type { Services } from "./services/index.ts";
+export { createAPIClient } from "./create-api-client.ts";

--- a/packages/tanstack-query-react-plugin/src/generateCode.ts
+++ b/packages/tanstack-query-react-plugin/src/generateCode.ts
@@ -19,7 +19,7 @@ import { getServiceIndexFactory } from './ts-factory/getServiceIndexFactory.js';
 interface OutputOptions extends OutputOptionsBase {
   fileHeader: string | undefined;
   servicesDirName: string;
-  explicitImportExtensions: boolean;
+  explicitImportExtensions: '.js' | '.ts' | undefined;
   exportSchemaTypes: boolean | undefined;
   operationPredefinedParameters: Array<PredefinedParametersGlob> | undefined;
 }
@@ -127,7 +127,7 @@ const generateServiceIndex = async (
   try {
     const code = astToString(
       getServiceIndexFactory(services, {
-        explicitImportExtensions: Boolean(output.explicitImportExtensions),
+        explicitImportExtensions: output.explicitImportExtensions,
       })
     );
 
@@ -157,7 +157,7 @@ const generateClient = async (spinner: Ora, output: OutputOptions) => {
     const code = astToString(
       getClientFactory({
         servicesDirName: output.servicesDirName,
-        explicitImportExtensions: Boolean(output.explicitImportExtensions),
+        explicitImportExtensions: output.explicitImportExtensions,
       })
     );
 
@@ -228,7 +228,7 @@ const generateIndex = async (
     const code = astToString(
       getIndexFactory({
         servicesDirName: output.servicesDirName,
-        explicitImportExtensions: Boolean(output.explicitImportExtensions),
+        explicitImportExtensions: output.explicitImportExtensions,
         openapiTypesImportPath: output.exportSchemaTypes
           ? serviceImports.openapiTypesImportPath
           : undefined,

--- a/packages/tanstack-query-react-plugin/src/plugin.spec.ts
+++ b/packages/tanstack-query-react-plugin/src/plugin.spec.ts
@@ -176,6 +176,7 @@ describe('TanStack Query React Client Generation', () => {
         '/mock-fs',
         '--export-openapi-types',
         '--explicit-import-extensions',
+        '.ts',
         '--openapi-types-import-path',
         '../../openapi.d.ts',
       ]);

--- a/packages/tanstack-query-react-plugin/src/plugin.ts
+++ b/packages/tanstack-query-react-plugin/src/plugin.ts
@@ -5,6 +5,7 @@ import {
 } from '@openapi-qraft/plugin/lib/predefineSchemaParameters';
 import { QraftCommand } from '@openapi-qraft/plugin/lib/QraftCommand';
 import { QraftCommandPlugin } from '@openapi-qraft/plugin/lib/QraftCommandPlugin';
+import { Option } from 'commander';
 import { generateCode } from './generateCode.js';
 
 export const plugin: QraftCommandPlugin = {
@@ -15,9 +16,13 @@ export const plugin: QraftCommandPlugin = {
         '--openapi-types-import-path <path>',
         'Path to schema types file (.d.ts), eg: "../schema.d.ts"'
       )
-      .option(
-        '--explicit-import-extensions',
-        'All import statements will include explicit `.js` extensions. Ideal for projects using ECMAScript modules.'
+      .addOption(
+        new Option(
+          '--explicit-import-extensions [extension]',
+          'All import statements will contain an explicit file extension. Ideal for projects using ECMAScript modules.'
+        )
+          .preset('.js')
+          .choices(['.js', '.ts'])
       )
       .option(
         '--export-openapi-types [bool]',

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getClientFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getClientFactory.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 
 type Options = {
   servicesDirName: string;
-  explicitImportExtensions: boolean;
+  explicitImportExtensions: '.js' | '.ts' | undefined;
 };
 
 export const getClientFactory = (options: Options) => {
@@ -79,7 +79,7 @@ const getClientImportsFactory = ({
         ])
       ),
       factory.createStringLiteral(
-        `./${servicesDirName}/index${explicitImportExtensions ? '.js' : ''}`
+        `./${servicesDirName}/index${explicitImportExtensions ?? ''}`
       ),
       undefined
     ),

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getIndexFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getIndexFactory.ts
@@ -8,10 +8,10 @@ export const getIndexFactory = ({
   explicitImportExtensions,
 }: {
   servicesDirName: string;
-  explicitImportExtensions: boolean;
+  explicitImportExtensions: '.js' | '.ts' | undefined;
 } & Partial<Pick<ServiceImportsFactoryOptions, 'openapiTypesImportPath'>>) => {
   const factory = ts.factory;
-  const importExtension = explicitImportExtensions ? '.js' : '';
+  const importExtension = explicitImportExtensions ?? '';
 
   return [
     ...(openapiTypesImportPath

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceIndexFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceIndexFactory.ts
@@ -1,7 +1,7 @@
 import { Service } from '@openapi-qraft/plugin/lib/open-api/getServices';
 import ts from 'typescript';
 
-type Options = { explicitImportExtensions: boolean };
+type Options = { explicitImportExtensions: '.js' | '.ts' | undefined };
 
 export const getServiceIndexFactory = (
   services: Service[],
@@ -96,7 +96,7 @@ const getServicesImportsFactory = (
         ])
       ),
       factory.createStringLiteral(
-        `./${fileBaseName}${explicitImportExtensions ? '.js' : ''}`
+        `./${fileBaseName}${explicitImportExtensions ?? ''}`
       )
     )
   );

--- a/website/docs/codegen/CLI/cli.mdx
+++ b/website/docs/codegen/CLI/cli.mdx
@@ -115,7 +115,8 @@ npx openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript http
         - If `tags` are used as the base name, operation names will be generated based on the `operationId` from the
           OpenAPI Operation, or from the path if `operationId` is not provided.
           You can use `--operation-name-modifier` to customize the operation names.
-- **`--explicit-import-extensions`:** Include explicit `.js` extensions in all import statements. Ideal for projects using ECMAScript modules when TypeScript's _--moduleResolution_ is `node16` or `nodenext` _(optional)_.
+- **`--explicit-import-extensions [extension]`**: All import statements will contain an explicit file extension. Ideal for projects using ECMAScript modules
+  when TypeScript's _--moduleResolution_ is `node16` or `nodenext`. Choices: `.js`, `.ts`, preset: `.js`. _(optional)_
 - **`--file-header <string>`:** Add a custom header to each generated file, useful for disabling linting rules or adding file
   comments _(optional)_.
   - Example: `--file-header '/* eslint-disable */'`


### PR DESCRIPTION
Enhance the existing `--explicit-import-extensions` option by adding support for the `.ts` extension. Previously, only `.js` was allowed, but now projects that require TypeScript imports can explicitly specify the `.ts` extension.

- **Updated Option**: `--explicit-import-extensions [extension]`
  - Now supports `.ts` in addition to the default `.js`.
  - Useful for projects utilizing TypeScript alongside ECMAScript modules.