### PR TITLE
fix: support for `--explicit-import-extensions .ts` when used `openapi-typescript-plugin`

### DIFF
--- a/.changeset/tender-horses-drop.md
+++ b/.changeset/tender-horses-drop.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/openapi-typescript-plugin': patch
+---
+
+Fixed support for the `--explicit-import-extensions .ts` option when using the `openapi-typescript-plugin`.

--- a/packages/openapi-typescript-plugin/src/lib/createOpenapiTypesImportPath.test.ts
+++ b/packages/openapi-typescript-plugin/src/lib/createOpenapiTypesImportPath.test.ts
@@ -2,27 +2,33 @@ import { describe, expect, it } from 'vitest';
 import { createOpenapiTypesImportPath } from './createOpenapiTypesImportPath.js';
 
 describe('createOpenapiTypesImportPath', () => {
-  it('should create import path with explicit extensions "true" and ".d.ts"', () => {
-    expect(createOpenapiTypesImportPath('schema.d.ts', true)).toBe(
+  it('should create import path with explicit extensions ".js" and ".d.ts"', () => {
+    expect(createOpenapiTypesImportPath('schema.d.ts', '.js')).toBe(
       '../schema.d.ts'
     );
   });
 
-  it('should create import path with explicit extensions "false" and ".d.ts"', () => {
-    expect(createOpenapiTypesImportPath('schema.d.ts', false)).toBe(
+  it('should create import path with explicit extensions "undefined" and ".d.ts"', () => {
+    expect(createOpenapiTypesImportPath('schema.d.ts', undefined)).toBe(
       '../schema.d.ts'
     );
   });
 
-  it('should create import path with explicit extensions "false" from ".ts"', () => {
-    expect(createOpenapiTypesImportPath('schema.ts', false)).toBe(
+  it('should create import path with explicit extensions "undefined" from ".ts"', () => {
+    expect(createOpenapiTypesImportPath('schema.ts', undefined)).toBe(
       '../schema.ts'
     );
   });
 
-  it('should create import path with explicit extensions "true" from ".ts"', () => {
-    expect(createOpenapiTypesImportPath('schema.ts', true)).toBe(
+  it('should create import path with explicit extensions ".js" from ".ts"', () => {
+    expect(createOpenapiTypesImportPath('schema.ts', '.js')).toBe(
       '../schema.js'
+    );
+  });
+
+  it('should create import path with explicit extensions ".ts" from ".ts"', () => {
+    expect(createOpenapiTypesImportPath('schema.ts', '.ts')).toBe(
+      '../schema.ts'
     );
   });
 });

--- a/packages/openapi-typescript-plugin/src/lib/createOpenapiTypesImportPath.ts
+++ b/packages/openapi-typescript-plugin/src/lib/createOpenapiTypesImportPath.ts
@@ -5,13 +5,13 @@
  */
 export function createOpenapiTypesImportPath(
   openapiTypesFileName: string,
-  explicitImportExtensions: boolean
+  explicitImportExtensions: '.ts' | '.js' | undefined
 ) {
   if (openapiTypesFileName.endsWith('.d.ts'))
     return `../${getTypeScriptFileBaseName(openapiTypesFileName)}.d.ts`;
 
   return explicitImportExtensions
-    ? `../${getTypeScriptFileBaseName(openapiTypesFileName)}.js`
+    ? `../${getTypeScriptFileBaseName(openapiTypesFileName)}${explicitImportExtensions}`
     : `../${openapiTypesFileName}`;
 }
 

--- a/packages/tanstack-query-react-plugin/src/plugin.spec.ts
+++ b/packages/tanstack-query-react-plugin/src/plugin.spec.ts
@@ -158,7 +158,7 @@ describe('TanStack Query React Client Generation', () => {
     });
   });
 
-  describe('--explicit-import-extensions --openapi-types-import-path ./openapi.d.ts', () => {
+  describe('--explicit-import-extensions .ts --openapi-types-import-path ./openapi.d.ts', () => {
     beforeAll(async () => {
       const { QraftCommand } = await import(
         '@openapi-qraft/plugin/lib/QraftCommand'


### PR DESCRIPTION
Fixed support for the `--explicit-import-extensions .ts` option when using the `openapi-typescript-plugin`.