### PR TITLE
feat(plugin): emit error for unused `--operation-name-modifier` options

### DIFF
--- a/.changeset/dirty-donkeys-watch.md
+++ b/.changeset/dirty-donkeys-watch.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/plugin': patch
+---
+
+Added validation for unused `--operation-name-modifier` options in the plugin. An explicit error is now thrown if a modifier is specified but does not match any paths or operations during code generation, ensuring all provided modifiers are purposeful and correctly configured.

--- a/packages/plugin/src/lib/QraftCommand.ts
+++ b/packages/plugin/src/lib/QraftCommand.ts
@@ -151,26 +151,37 @@ export class QraftCommand extends Command {
 
       if (operationNameModifierErrors.length) {
         operationNameModifierErrors.forEach((error) => {
-          spinner.fail(
-            [
-              c.red.bold(
-                `Error occurred during operation name modifier setup: '${error.serviceName}.${error.originalOperationName}' to '${error.replacedOperationName}'`
-              ),
-              c.yellow(
-                error.modifiers
-                  .map(
-                    ({
-                      pathGlobs,
-                      operationNameModifierRegex,
-                      operationNameModifierReplace,
-                    }) =>
-                      `Conflicting operation name modifier: '${pathGlobs}': '${operationNameModifierRegex}' => '${operationNameModifierReplace}'`
-                  )
-                  .join('\n')
-              ),
-            ].join('\n')
-          );
+          if (error.type === 'conflictingOperationNameModifier') {
+            spinner.fail(
+              [
+                c.red.bold(
+                  `Error occurred during operation name modifier setup: '${error.serviceName}.${error.originalOperationName}' to '${error.replacedOperationName}'`
+                ),
+                c.yellow(
+                  error.modifiers
+                    .map(
+                      ({
+                        pathGlobs,
+                        operationNameModifierRegex,
+                        operationNameModifierReplace,
+                      }) =>
+                        `Conflicting operation name modifier: '${pathGlobs}': '${operationNameModifierRegex}' => '${operationNameModifierReplace}'`
+                    )
+                    .join('\n')
+                ),
+              ].join('\n')
+            );
+          } else if (error.type === 'unusedOperationNameModifier') {
+            spinner.fail(
+              [
+                c.yellow.bold(
+                  `Unused operation name modifier: '${error.modifier.pathGlobs}': '${error.modifier.operationNameModifierRegex}' => '${error.modifier.operationNameModifierReplace}'`
+                ),
+              ].join('\n')
+            );
+          }
         });
+
         process.exit(1);
       }
 

--- a/packages/plugin/src/lib/processOperationNameModifierOption.test.ts
+++ b/packages/plugin/src/lib/processOperationNameModifierOption.test.ts
@@ -163,6 +163,7 @@ describe('# processOperationNameModifierOption', () => {
             "originalOperationName": "postEntitiesIdDocuments",
             "replacedOperationName": "createOne",
             "serviceName": "entities",
+            "type": "conflictingOperationNameModifier",
           },
         ]
       `);
@@ -191,6 +192,7 @@ describe('# processOperationNameModifierOption', () => {
             "originalOperationName": "getApprovalPoliciesId",
             "replacedOperationName": "deleteOne",
             "serviceName": "approvalPolicies",
+            "type": "conflictingOperationNameModifier",
           },
           {
             "modifiers": [
@@ -204,6 +206,33 @@ describe('# processOperationNameModifierOption', () => {
             "originalOperationName": "deleteApprovalPoliciesId",
             "replacedOperationName": "deleteOne",
             "serviceName": "approvalPolicies",
+            "type": "conflictingOperationNameModifier",
+          },
+        ]
+      `);
+    });
+
+    it('generates errors for unused modifiers', () => {
+      const { errors } = processOperationNameModifierOption(
+        parseOperationNameModifier(
+          // used modifier
+          '/approval_policies/{approval_policy_id}:delete[A-Za-z]+sId ==> deleteOne',
+          // unused modifier
+          '/some/{unused}/modifier:delete[A-Za-z]+sId ==> deleteOne'
+        ),
+        getServices(openAPI)
+      );
+
+      expect(errors).toMatchInlineSnapshot(`
+        [
+          {
+            "modifier": {
+              "methods": undefined,
+              "operationNameModifierRegex": "delete[A-Za-z]+sId",
+              "operationNameModifierReplace": "deleteOne",
+              "pathGlobs": "/some/{unused}/modifier",
+            },
+            "type": "unusedOperationNameModifier",
           },
         ]
       `);


### PR DESCRIPTION
This PR enhances the behavior of the `--operation-name-modifier` option used for modifying operation names in generated services. If an unused modifier is provided (i.e., it doesn't match any paths or operations during code generation), the plugin will now throw an explicit error to notify the developer.

#### Key Updates:
- Added validation for unused `--operation-name-modifier` options.
- If a modifier is specified but not applied to any operations or paths, an error will be emitted during the generation process.

#### Why This Matters:
Previously, unused modifiers might have been ignored silently, leading to potential misconfigurations or unintentional behavior. With this update, the developer is informed immediately, ensuring that all provided modifiers are purposeful and correctly configured.

#### Example:
When running the codegen command:
```bash
openapi-qraft --operation-name-modifier '/filez/list:[a-zA-Z]+List => findAll'
```

If the specified modifier doesn’t match any paths or operations, the following error will be emitted:

```
✖ Unused operation name modifier: '/filez/list': '[a-zA-Z]+List' => 'findAll'
```