### PR TITLE
refactor(227): `Service` and `ServiceOperation` types refactoring

### DIFF
--- a/.changeset/swift-rivers-hug.md
+++ b/.changeset/swift-rivers-hug.md
@@ -1,0 +1,6 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/plugin': patch
+---
+
+Refactor `Service` and `ServiceOperation` types.

--- a/packages/plugin/src/lib/QraftCommand.ts
+++ b/packages/plugin/src/lib/QraftCommand.ts
@@ -1,5 +1,4 @@
 import type { Option } from 'commander';
-import type { Service } from './open-api/getServices.js';
 import { sep } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL, URL } from 'node:url';
@@ -12,6 +11,7 @@ import { GeneratorFile } from './GeneratorFile.js';
 import { handleSchemaInput } from './handleSchemaInput.js';
 import { getServices } from './open-api/getServices.js';
 import { OpenAPISchemaType } from './open-api/OpenAPISchemaType.js';
+import { OpenAPIService } from './open-api/OpenAPIService.js';
 import { readSchema } from './open-api/readSchema.js';
 import { OutputOptions } from './OutputOptions.js';
 import {
@@ -377,7 +377,7 @@ export type QraftCommandActionCallback = (
     /**
      * OpenAPI services
      */
-    services: Service[];
+    services: OpenAPIService[];
     /**
      * OpenAPI schema
      */

--- a/packages/plugin/src/lib/open-api/OpenAPIService.ts
+++ b/packages/plugin/src/lib/open-api/OpenAPIService.ts
@@ -1,0 +1,40 @@
+import type { OpenAPISchemaType } from './OpenAPISchemaType.js';
+
+export type OpenAPIService = {
+  name: string;
+  variableName: string;
+  typeName: string;
+  fileBaseName: string;
+  operations: ServiceOperation[];
+};
+
+export type ServiceOperation = {
+  method:
+    | 'get'
+    | 'put'
+    | 'post'
+    | 'patch'
+    | 'delete'
+    | 'options'
+    | 'head'
+    | 'trace';
+  path: string;
+  name: string;
+  description: string | undefined;
+  summary: string | undefined;
+  deprecated: boolean | undefined;
+  errors: Record<string, string | undefined>;
+  requestBody: OpenAPISchemaType['paths'][string]['post']['requestBody'];
+  success: Record<string, string | undefined>;
+  parameters:
+    | {
+        name: string;
+        in: 'header' | 'query' | 'cookie';
+        description: string;
+        required: boolean;
+        schema: any;
+        example: string | undefined;
+      }[]
+    | undefined;
+  security: Array<Record<string, string[] | undefined>> | undefined;
+};

--- a/packages/plugin/src/lib/open-api/getServices.ts
+++ b/packages/plugin/src/lib/open-api/getServices.ts
@@ -7,51 +7,23 @@ import {
   ServiceBaseNameByEndpointOption,
 } from './getServiceNamesByOperationEndpoint.js';
 import { getServiceNamesByOperationTags } from './getServiceNamesByOperationTags.js';
+import {
+  OpenAPIService,
+  ServiceOperation as ServiceOperationStable,
+} from './OpenAPIService.js';
 import { replaceRefParametersWithComponent } from './replaceRefParametersWithComponent.js';
 
 export type ServiceBaseName = ServiceBaseNameByEndpointOption | 'tags';
 
 /**
- * @deprecated move to separate file
+ * @deprecated use `OpenAPIService` instead from './OpenAPIService.js'
  */
-export type Service = {
-  name: string;
-  variableName: string;
-  typeName: string;
-  fileBaseName: string;
-  operations: ServiceOperation[];
-};
+export type Service = OpenAPIService;
 
-export type ServiceOperation = {
-  method:
-    | 'get'
-    | 'put'
-    | 'post'
-    | 'patch'
-    | 'delete'
-    | 'options'
-    | 'head'
-    | 'trace';
-  path: string;
-  name: string;
-  description: string | undefined;
-  summary: string | undefined;
-  deprecated: boolean | undefined;
-  errors: Record<string, string | undefined>;
-  requestBody: OpenAPISchemaType['paths'][string]['post']['requestBody'];
-  success: Record<string, string | undefined>;
-  parameters:
-    | {
-        name: string;
-        in: 'header' | 'query' | 'cookie';
-        description: string;
-        required: boolean;
-        schema: any;
-        example: string | undefined;
-      }[]
-    | undefined;
-  security: Array<Record<string, string[] | undefined>> | undefined;
-};
+/**
+ * @deprecated use `ServiceOperation` instead from './OpenAPIService.js'
+ */
+export type ServiceOperation = ServiceOperationStable;
 
 export interface ServiceOutputOptions {
   postfixServices?: string; // todo::rename to `postfixService`
@@ -68,7 +40,7 @@ export const getServices = (
   const paths = openApiJson.paths;
   const parametersComponents = openApiJson.components.parameters ?? {};
 
-  const services = new Map<string, Service>();
+  const services = new Map<string, OpenAPIService>();
 
   for (const path in paths) {
     if (!Object.prototype.hasOwnProperty.call(paths, path)) continue;
@@ -184,4 +156,4 @@ const supportedHTTPMethods = Object.values({
   options: 'options',
   head: 'head',
   trace: 'trace',
-} satisfies { [key in ServiceOperation['method']]: key });
+} satisfies { [key in ServiceOperationStable['method']]: key });

--- a/packages/plugin/src/lib/parseOperationGlobs.ts
+++ b/packages/plugin/src/lib/parseOperationGlobs.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from './open-api/getServices.js';
+import { ServiceOperation } from './open-api/OpenAPIService.js';
 import { splitCommaSeparatedGlobs } from './splitCommaSeparatedGlobs.js';
 
 /**

--- a/packages/plugin/src/lib/processOperationNameModifierOption.ts
+++ b/packages/plugin/src/lib/processOperationNameModifierOption.ts
@@ -1,6 +1,6 @@
 import { createServicePathMatch } from './createServicePathMatch.js';
 import { getOperationIdName } from './open-api/getOperationName.js';
-import { Service } from './open-api/getServices.js';
+import { OpenAPIService } from './open-api/OpenAPIService.js';
 import {
   OperationGlobMethods,
   parseOperationGlobs,
@@ -9,7 +9,7 @@ import { splitCommaSeparatedGlobs } from './splitCommaSeparatedGlobs.js';
 
 export const processOperationNameModifierOption = (
   modifiers: OperationNameModifier[],
-  services: Service[]
+  services: OpenAPIService[]
 ) => {
   if (!modifiers.length)
     return {

--- a/packages/tanstack-query-react-plugin/src/generateCode.ts
+++ b/packages/tanstack-query-react-plugin/src/generateCode.ts
@@ -1,7 +1,7 @@
 import { URL } from 'node:url';
 import { formatFileHeader } from '@openapi-qraft/plugin/lib/formatFileHeader';
 import { GeneratorFile } from '@openapi-qraft/plugin/lib/GeneratorFile';
-import { Service } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { OpenAPIService } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import { OutputOptions as OutputOptionsBase } from '@openapi-qraft/plugin/lib/OutputOptions';
 import { PredefinedParametersGlob } from '@openapi-qraft/plugin/lib/predefineSchemaParameters';
 import c from 'ansi-colors';
@@ -31,7 +31,7 @@ export const generateCode = async ({
   output,
 }: {
   spinner: Ora;
-  services: Service[];
+  services: OpenAPIService[];
   serviceImports: ServiceImportsFactoryOptions;
   output: OutputOptions;
 }) => {
@@ -58,7 +58,7 @@ const composeServicesDirPath = (
 
 const generateServices = async (
   spinner: Ora,
-  services: Service[],
+  services: OpenAPIService[],
   serviceImports: ServiceImportsFactoryOptions,
   output: OutputOptions
 ) => {
@@ -112,7 +112,7 @@ const generateServices = async (
 
 const generateServiceIndex = async (
   spinner: Ora,
-  services: Service[],
+  services: OpenAPIService[],
   output: OutputOptions
 ) => {
   spinner.start('Generating services index');

--- a/packages/tanstack-query-react-plugin/src/lib/createOperationCommonTSDoc.ts
+++ b/packages/tanstack-query-react-plugin/src/lib/createOperationCommonTSDoc.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 
 export const createOperationCommonTSDoc = (operation: ServiceOperation) => {
   return [

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelCase from 'camelcase';
 import ts from 'typescript';
 import { createOperationCommonTSDoc } from '../lib/createOperationCommonTSDoc.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceIndexFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceIndexFactory.ts
@@ -1,10 +1,10 @@
-import { Service } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { OpenAPIService } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import ts from 'typescript';
 
 type Options = { explicitImportExtensions: '.js' | '.ts' | undefined };
 
 export const getServiceIndexFactory = (
-  services: Service[],
+  services: OpenAPIService[],
   options: Options
 ) => {
   return [
@@ -14,7 +14,7 @@ export const getServiceIndexFactory = (
   ];
 };
 
-const getServiceIndexInterfaceFactory = (services: Service[]) => {
+const getServiceIndexInterfaceFactory = (services: OpenAPIService[]) => {
   const factory = ts.factory;
 
   return factory.createTypeAliasDeclaration(
@@ -37,7 +37,7 @@ const getServiceIndexInterfaceFactory = (services: Service[]) => {
   );
 };
 
-const getServiceIndexVariableFactory = (services: Service[]) => {
+const getServiceIndexVariableFactory = (services: OpenAPIService[]) => {
   const factory = ts.factory;
 
   return factory.createVariableStatement(
@@ -71,7 +71,7 @@ const getServiceIndexVariableFactory = (services: Service[]) => {
 };
 
 const getServicesImportsFactory = (
-  services: Service[],
+  services: OpenAPIService[],
   { explicitImportExtensions }: Options
 ) => {
   const factory = ts.factory;

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createOperationMethodTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createOperationMethodTSDocExample.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import { createUseInfiniteQueryOperationTSDocExample } from './createUseInfiniteQueryOperationTSDocExample.js';
 import { createUseIsFetchingOperationTSDocExample } from './createUseIsFetchingOperationTSDocExample.js';
 import { createUseIsMutatingOperationTSDocExample } from './createUseIsMutatingOperationTSDocExample.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseInfiniteQueryOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseInfiniteQueryOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelcase from 'camelcase';
 import ts from 'typescript';
 import { astToString } from '../astToString.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseIsFetchingOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseIsFetchingOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelcase from 'camelcase';
 import ts from 'typescript';
 import { astToString } from '../astToString.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseIsMutatingOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseIsMutatingOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelcase from 'camelcase';
 import ts from 'typescript';
 import { createOperationCommonTSDoc } from '../../lib/createOperationCommonTSDoc.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseMutationOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseMutationOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import ts from 'typescript';
 import { astToString } from '../astToString.js';
 import { createOperationMethodCallExpressionExampleNode } from './lib/createOperationMethodCallExpressionExampleNode.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseMutationStateOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseMutationStateOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelcase from 'camelcase';
 import ts from 'typescript';
 import { createOperationCommonTSDoc } from '../../lib/createOperationCommonTSDoc.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseQueriesOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseQueriesOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelcase from 'camelcase';
 import ts from 'typescript';
 import { createOperationCommonTSDoc } from '../../lib/createOperationCommonTSDoc.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseQueryOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseQueryOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import ts from 'typescript';
 import { createOperationCommonTSDoc } from '../../lib/createOperationCommonTSDoc.js';
 import { astToString } from '../astToString.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseSuspenseInfiniteQueryOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseSuspenseInfiniteQueryOperationTSDocExample.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import ts from 'typescript';
 import { astToString } from '../astToString.js';
 import { createInfiniteQueryOptionsArgumentExamplePropertyAssignmentNodes } from './createUseInfiniteQueryOperationTSDocExample.js';

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/lib/createOperationMethodCallExpressionExampleNode.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/lib/createOperationMethodCallExpressionExampleNode.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import ts from 'typescript';
 
 export const createOperationMethodCallExpressionExampleNode = (

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/lib/createOperationMethodParametersExampleNodes.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/lib/createOperationMethodParametersExampleNodes.ts
@@ -1,4 +1,4 @@
-import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/getServices';
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
 import camelcase from 'camelcase';
 import ts from 'typescript';
 


### PR DESCRIPTION
Move `Service` and `ServiceOperation` into separate files and rename `Service` to `OpenAPIService`.