### PR TITLE
fix: `commander` `"peerDependencies"`

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,20 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@openapi-qraft/e2e": "1.0.0",
+    "@openapi-qraft/cli": "2.0.0",
+    "@openapi-qraft/eslint-config": "1.0.0",
+    "@openapi-qraft/openapi-typescript-plugin": "1.2.0",
+    "@openapi-qraft/plugin": "2.0.0",
+    "@openapi-qraft/react": "2.0.0",
+    "@openapi-qraft/rollup-config": "1.1.0",
+    "@openapi-qraft/tanstack-query-react-plugin": "2.0.0",
+    "@openapi-qraft/tanstack-query-react-types": "2.0.0",
+    "@openapi-qraft/test-fixtures": "1.0.0",
+    "@openapi-qraft/ts-factory-code-generator": "1.0.0",
+    "playground": "0.0.14",
+    "openapi-qraft-website": "0.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/tender-pans-joke.md
+++ b/.changeset/tender-pans-joke.md
@@ -1,0 +1,7 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/openapi-typescript-plugin': patch
+'@openapi-qraft/plugin': patch
+---
+
+Ensure external libraries are declared in `peerDependencies` to prevent conflicts and duplication.

--- a/packages/openapi-typescript-plugin/package.json
+++ b/packages/openapi-typescript-plugin/package.json
@@ -39,6 +39,14 @@
     "rimraf": "^5.0.10",
     "vitest": "^2.1.8"
   },
+  "peerDependencies": {
+    "commander": "^11.1.0"
+  },
+  "peerDependenciesMeta": {
+    "commander": {
+      "optional": false
+    }
+  },
   "files": [
     "dist",
     "src",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -44,6 +44,14 @@
     "typescript": "^5.6.2",
     "vitest": "^2.1.8"
   },
+  "peerDependencies": {
+    "commander": "^11.1.0"
+  },
+  "peerDependenciesMeta": {
+    "commander": {
+      "optional": false
+    }
+  },
   "files": [
     "dist",
     "src",

--- a/packages/tanstack-query-react-plugin/package.json
+++ b/packages/tanstack-query-react-plugin/package.json
@@ -40,6 +40,14 @@
     "rimraf": "^5.0.10",
     "vitest": "^2.1.8"
   },
+  "peerDependencies": {
+    "commander": "^11.1.0"
+  },
+  "peerDependenciesMeta": {
+    "commander": {
+      "optional": false
+    }
+  },
   "files": [
     "dist",
     "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5909,6 +5909,11 @@ __metadata:
     rimraf: "npm:^5.0.10"
     typescript: "npm:^5.6.2"
     vitest: "npm:^2.1.8"
+  peerDependencies:
+    commander: ^11.1.0
+  peerDependenciesMeta:
+    commander:
+      optional: false
   languageName: unknown
   linkType: soft
 
@@ -5931,6 +5936,11 @@ __metadata:
     typescript: "npm:^5.6.2"
     vitest: "npm:^2.1.8"
     yaml: "npm:^2.5.1"
+  peerDependencies:
+    commander: ^11.1.0
+  peerDependenciesMeta:
+    commander:
+      optional: false
   languageName: unknown
   linkType: soft
 
@@ -6002,6 +6012,11 @@ __metadata:
     rimraf: "npm:^5.0.10"
     typescript: "npm:^5.6.2"
     vitest: "npm:^2.1.8"
+  peerDependencies:
+    commander: ^11.1.0
+  peerDependenciesMeta:
+    commander:
+      optional: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Ensure external libraries are declared in `peerDependencies` to prevent conflicts and duplication.