### PR TITLE
feat: add TSDoc @example generation for `useSuspenseQuery` and `useSuspenseQueries`

### DIFF
--- a/.changeset/mighty-toys-sort.md
+++ b/.changeset/mighty-toys-sort.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+---
+
+Added TSDoc `@example` generation for `useSuspenseQuery` and `useSuspenseQueries` hooks.

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -441,8 +441,27 @@ export interface ApprovalPoliciesService {
             combine?: (results: Array<WithOptional<UseSuspenseQueryResult<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError>, "data">>) => TCombinedResult;
         }): TCombinedResult;
         /**
+         * Performs asynchronous data fetching with Suspense support.
+         * Similar to useQuery but integrates with React Suspense for loading states.
+         *
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQuery|`useSuspenseQuery(...)` documentation}
+         * @example Suspense Query with parameters
+         * ```ts
+         * const data = qraft.approvalPoliciesService.getApprovalPoliciesId.useSuspenseQuery({
+         *     header: {
+         *         "x-monite-version": "2023-06-04",
+         *         "x-monite-entity-id": xMoniteEntityId
+         *     },
+         *     path: {
+         *         approval_policy_id: approvalPolicyId
+         *     },
+         *     query: {
+         *         items_order: itemsOrder
+         *     }
+         * })
+         * ```
          */
         useSuspenseQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options?: Omit<UseSuspenseQueryOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         schema: GetApprovalPoliciesIdSchema;

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -433,8 +433,77 @@ export interface ApprovalPoliciesService {
          */
         useSuspenseInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options: Omit<UseSuspenseInfiniteQueryOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, OperationInfiniteData<TData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetApprovalPoliciesIdData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdError | Error>;
         /**
+         * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
+         * Similar to useQueries but integrates with React Suspense for loading states.
+         *
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQueries|`useSuspenseQueries(...)` documentation}
+         * @example Basic usage with Suspense
+         * ```ts
+         * const getApprovalPoliciesIdData = qraft.approvalPoliciesService.getApprovalPoliciesId.useSuspenseQueries({
+         *     queries: [
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04",
+         *                 "x-monite-entity-id": xMoniteEntityId1
+         *             },
+         *             path: {
+         *                 approval_policy_id: approvalPolicyId1
+         *             },
+         *             query: {
+         *                 items_order: itemsOrder1
+         *             }
+         *         },
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04",
+         *                 "x-monite-entity-id": xMoniteEntityId2
+         *             },
+         *             path: {
+         *                 approval_policy_id: approvalPolicyId2
+         *             },
+         *             query: {
+         *                 items_order: itemsOrder2
+         *             }
+         *         }
+         *     ]
+         * });
+         * getApprovalPoliciesIdResults.forEach(({ isSuccess, data, error }) => console.log({ isSuccess, data, error }));
+         * ```
+         * @example With data transformation using combine
+         * ```ts
+         * const getApprovalPoliciesIdCombinedData = qraft.approvalPoliciesService.getApprovalPoliciesId.useSuspenseQueries({
+         *     combine: results => results.map(result => result.data),
+         *     queries: [
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04",
+         *                 "x-monite-entity-id": xMoniteEntityId1
+         *             },
+         *             path: {
+         *                 approval_policy_id: approvalPolicyId1
+         *             },
+         *             query: {
+         *                 items_order: itemsOrder1
+         *             }
+         *         },
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04",
+         *                 "x-monite-entity-id": xMoniteEntityId2
+         *             },
+         *             path: {
+         *                 approval_policy_id: approvalPolicyId2
+         *             },
+         *             query: {
+         *                 items_order: itemsOrder2
+         *             }
+         *         }
+         *     ]
+         * });
+         * getApprovalPoliciesIdCombinedData.forEach(data => console.log({ data }));
+         * ```
          */
         useSuspenseQueries<T extends Array<UseQueryOptionsForUseSuspenseQuery<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters, GetApprovalPoliciesIdData, GetApprovalPoliciesIdError>>, TCombinedResult = Array<UseSuspenseQueryResult<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError>>>(options: {
             queries: T;

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -313,7 +313,62 @@ export interface FilesService {
          * ```
          */
         useSuspenseInfiniteQuery<TPageParam extends GetFilesParameters, TData = GetFilesData>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options: Omit<UseSuspenseInfiniteQueryOptions<GetFilesData, GetFilesError, OperationInfiniteData<TData, GetFilesParameters>, GetFilesData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFilesData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetFilesParameters>, GetFilesError | Error>;
-        /** @summary Get a files by ID */
+        /**
+         * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
+         * Similar to useQueries but integrates with React Suspense for loading states.
+         *
+         * @summary Get a files by ID
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQueries|`useSuspenseQueries(...)` documentation}
+         * @example Basic usage with Suspense
+         * ```ts
+         * const getFilesData = qraft.filesService.getFiles.useSuspenseQueries({
+         *     queries: [
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn1
+         *             }
+         *         },
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn2
+         *             }
+         *         }
+         *     ]
+         * });
+         * getFilesResults.forEach(({ isSuccess, data, error }) => console.log({ isSuccess, data, error }));
+         * ```
+         * @example With data transformation using combine
+         * ```ts
+         * const getFilesCombinedData = qraft.filesService.getFiles.useSuspenseQueries({
+         *     combine: results => results.map(result => result.data),
+         *     queries: [
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn1
+         *             }
+         *         },
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn2
+         *             }
+         *         }
+         *     ]
+         * });
+         * getFilesCombinedData.forEach(data => console.log({ data }));
+         * ```
+         */
         useSuspenseQueries<T extends Array<UseQueryOptionsForUseSuspenseQuery<GetFilesSchema, GetFilesParameters, GetFilesData, GetFilesError>>, TCombinedResult = Array<UseSuspenseQueryResult<GetFilesData, GetFilesError>>>(options: {
             queries: T;
             combine?: (results: Array<WithOptional<UseSuspenseQueryResult<GetFilesData, GetFilesError>, "data">>) => TCombinedResult;
@@ -957,8 +1012,61 @@ export interface FilesService {
          */
         useSuspenseInfiniteQuery<TPageParam extends GetFileListParameters, TData = GetFileListData>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options: Omit<UseSuspenseInfiniteQueryOptions<GetFileListData, GetFileListError, OperationInfiniteData<TData, GetFileListParameters>, GetFileListData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFileListData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetFileListParameters>, GetFileListError | Error>;
         /**
+         * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
+         * Similar to useQueries but integrates with React Suspense for loading states.
+         *
          * @deprecated
          * @summary Get a file list
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQueries|`useSuspenseQueries(...)` documentation}
+         * @example Basic usage with Suspense
+         * ```ts
+         * const getFileListData = qraft.filesService.getFileList.useSuspenseQueries({
+         *     queries: [
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn1
+         *             }
+         *         },
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn2
+         *             }
+         *         }
+         *     ]
+         * });
+         * getFileListResults.forEach(({ isSuccess, data, error }) => console.log({ isSuccess, data, error }));
+         * ```
+         * @example With data transformation using combine
+         * ```ts
+         * const getFileListCombinedData = qraft.filesService.getFileList.useSuspenseQueries({
+         *     combine: results => results.map(result => result.data),
+         *     queries: [
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn1
+         *             }
+         *         },
+         *         {
+         *             header: {
+         *                 "x-monite-version": "2023-06-04"
+         *             },
+         *             query: {
+         *                 id__in: idIn2
+         *             }
+         *         }
+         *     ]
+         * });
+         * getFileListCombinedData.forEach(data => console.log({ data }));
+         * ```
          */
         useSuspenseQueries<T extends Array<UseQueryOptionsForUseSuspenseQuery<GetFileListSchema, GetFileListParameters, GetFileListData, GetFileListError>>, TCombinedResult = Array<UseSuspenseQueryResult<GetFileListData, GetFileListError>>>(options: {
             queries: T;

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -318,7 +318,24 @@ export interface FilesService {
             queries: T;
             combine?: (results: Array<WithOptional<UseSuspenseQueryResult<GetFilesData, GetFilesError>, "data">>) => TCombinedResult;
         }): TCombinedResult;
-        /** @summary Get a files by ID */
+        /**
+         * Performs asynchronous data fetching with Suspense support.
+         * Similar to useQuery but integrates with React Suspense for loading states.
+         *
+         * @summary Get a files by ID
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQuery|`useSuspenseQuery(...)` documentation}
+         * @example Suspense Query with parameters
+         * ```ts
+         * const data = qraft.filesService.getFiles.useSuspenseQuery({
+         *     header: {
+         *         "x-monite-version": "2023-06-04"
+         *     },
+         *     query: {
+         *         id__in: idIn
+         *     }
+         * })
+         * ```
+         */
         useSuspenseQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options?: Omit<UseSuspenseQueryOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetFilesError | Error>;
         schema: GetFilesSchema;
         types: {
@@ -948,8 +965,27 @@ export interface FilesService {
             combine?: (results: Array<WithOptional<UseSuspenseQueryResult<GetFileListData, GetFileListError>, "data">>) => TCombinedResult;
         }): TCombinedResult;
         /**
+         * Performs asynchronous data fetching with Suspense support.
+         * Similar to useQuery but integrates with React Suspense for loading states.
+         *
          * @deprecated
          * @summary Get a file list
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQuery|`useSuspenseQuery(...)` documentation}
+         * @example Suspense Query without parameters
+         * ```ts
+         * const data = qraft.filesService.getFileList.useSuspenseQuery()
+         * ```
+         * @example Suspense Query with parameters
+         * ```ts
+         * const data = qraft.filesService.getFileList.useSuspenseQuery({
+         *     header: {
+         *         "x-monite-version": "2023-06-04"
+         *     },
+         *     query: {
+         *         id__in: idIn
+         *     }
+         * })
+         * ```
          */
         useSuspenseQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options?: Omit<UseSuspenseQueryOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetFileListError | Error>;
         schema: GetFileListSchema;

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createOperationMethodTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createOperationMethodTSDocExample.ts
@@ -7,6 +7,7 @@ import { createUseMutationStateOperationTSDocExample } from './createUseMutation
 import { createUseQueriesOperationTSDocExample } from './createUseQueriesOperationTSDocExample.js';
 import { createUseQueryOperationTSDocExample } from './createUseQueryOperationTSDocExample.js';
 import { createUseSuspenseInfiniteQueryOperationTSDocExample } from './createUseSuspenseInfiniteQueryOperationTSDocExample.js';
+import { createUseSuspenseQueryOperationTSDocExample } from './createUseSuspenseQueryOperationTSDocExample.js';
 
 export const createOperationMethodTSDocExample = (
   operation: ServiceOperation,
@@ -24,6 +25,11 @@ export const createOperationMethodTSDocExample = (
         operation,
         serviceVariableName
       );
+    case 'useSuspenseQuery':
+      return createUseSuspenseQueryOperationTSDocExample(
+        operation,
+        serviceVariableName
+      );
     case 'useMutation':
       return createUseMutationOperationTSDocExample(
         operation,
@@ -31,6 +37,11 @@ export const createOperationMethodTSDocExample = (
       );
     case 'useInfiniteQuery':
       return createUseInfiniteQueryOperationTSDocExample(
+        operation,
+        serviceVariableName
+      );
+    case 'useSuspenseInfiniteQuery':
+      return createUseSuspenseInfiniteQueryOperationTSDocExample(
         operation,
         serviceVariableName
       );
@@ -51,11 +62,6 @@ export const createOperationMethodTSDocExample = (
       );
     case 'useQueries':
       return createUseQueriesOperationTSDocExample(
-        operation,
-        serviceVariableName
-      );
-    case 'useSuspenseInfiniteQuery':
-      return createUseSuspenseInfiniteQueryOperationTSDocExample(
         operation,
         serviceVariableName
       );

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createOperationMethodTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createOperationMethodTSDocExample.ts
@@ -7,6 +7,7 @@ import { createUseMutationStateOperationTSDocExample } from './createUseMutation
 import { createUseQueriesOperationTSDocExample } from './createUseQueriesOperationTSDocExample.js';
 import { createUseQueryOperationTSDocExample } from './createUseQueryOperationTSDocExample.js';
 import { createUseSuspenseInfiniteQueryOperationTSDocExample } from './createUseSuspenseInfiniteQueryOperationTSDocExample.js';
+import { createUseSuspenseQueriesOperationTSDocExample } from './createUseSuspenseQueriesOperationTSDocExample.js';
 import { createUseSuspenseQueryOperationTSDocExample } from './createUseSuspenseQueryOperationTSDocExample.js';
 
 export const createOperationMethodTSDocExample = (
@@ -62,6 +63,11 @@ export const createOperationMethodTSDocExample = (
       );
     case 'useQueries':
       return createUseQueriesOperationTSDocExample(
+        operation,
+        serviceVariableName
+      );
+    case 'useSuspenseQueries':
+      return createUseSuspenseQueriesOperationTSDocExample(
         operation,
         serviceVariableName
       );

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseQueriesOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseQueriesOperationTSDocExample.ts
@@ -40,25 +40,7 @@ export const createUseQueriesOperationTSDocExample = (
                     [
                       factory.createPropertyAssignment(
                         factory.createIdentifier('queries'),
-                        factory.createArrayLiteralExpression(
-                          [
-                            factory.createObjectLiteralExpression(
-                              createOperationMethodParametersExampleNodes(
-                                operation,
-                                (parameter) => camelcase(`${parameter.name}-1`)
-                              ),
-                              true
-                            ),
-                            factory.createObjectLiteralExpression(
-                              createOperationMethodParametersExampleNodes(
-                                operation,
-                                (parameter) => camelcase(`${parameter.name}-2`)
-                              ),
-                              true
-                            ),
-                          ],
-                          true
-                        )
+                        createQueriesArrayExpression(operation, factory)
                       ),
                     ],
                     true
@@ -70,68 +52,9 @@ export const createUseQueriesOperationTSDocExample = (
           ts.NodeFlags.Const
         )
       ),
-      factory.createExpressionStatement(
-        factory.createCallExpression(
-          factory.createPropertyAccessExpression(
-            factory.createIdentifier(camelcase(operation.name + '-results')),
-            factory.createIdentifier('forEach')
-          ),
-          undefined,
-          [
-            factory.createArrowFunction(
-              undefined,
-              undefined,
-              [
-                factory.createParameterDeclaration(
-                  undefined,
-                  undefined,
-                  factory.createObjectBindingPattern([
-                    factory.createBindingElement(
-                      undefined,
-                      undefined,
-                      factory.createIdentifier('isSuccess')
-                    ),
-                    factory.createBindingElement(
-                      undefined,
-                      undefined,
-                      factory.createIdentifier('data')
-                    ),
-                    factory.createBindingElement(
-                      undefined,
-                      undefined,
-                      factory.createIdentifier('error')
-                    ),
-                  ])
-                ),
-              ],
-              undefined,
-              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-              factory.createCallExpression(
-                factory.createPropertyAccessExpression(
-                  factory.createIdentifier('console'),
-                  factory.createIdentifier('log')
-                ),
-                undefined,
-                [
-                  factory.createObjectLiteralExpression(
-                    [
-                      factory.createShorthandPropertyAssignment(
-                        factory.createIdentifier('isSuccess')
-                      ),
-                      factory.createShorthandPropertyAssignment(
-                        factory.createIdentifier('data')
-                      ),
-                      factory.createShorthandPropertyAssignment(
-                        factory.createIdentifier('error')
-                      ),
-                    ],
-                    false
-                  ),
-                ]
-              )
-            ),
-          ]
-        )
+      createResultsForEachExpression(
+        camelcase(operation.name + '-results'),
+        factory
       ),
     ])
       .trim()
@@ -162,71 +85,11 @@ export const createUseQueriesOperationTSDocExample = (
                     [
                       factory.createPropertyAssignment(
                         factory.createIdentifier('combine'),
-                        factory.createArrowFunction(
-                          undefined,
-                          undefined,
-                          [
-                            factory.createParameterDeclaration(
-                              undefined,
-                              undefined,
-                              factory.createIdentifier('results')
-                            ),
-                          ],
-                          undefined,
-                          factory.createToken(
-                            ts.SyntaxKind.EqualsGreaterThanToken
-                          ),
-                          factory.createCallExpression(
-                            factory.createPropertyAccessExpression(
-                              factory.createIdentifier('results'),
-                              factory.createIdentifier('map')
-                            ),
-                            undefined,
-                            [
-                              factory.createArrowFunction(
-                                undefined,
-                                undefined,
-                                [
-                                  factory.createParameterDeclaration(
-                                    undefined,
-                                    undefined,
-                                    factory.createIdentifier('result')
-                                  ),
-                                ],
-                                undefined,
-                                factory.createToken(
-                                  ts.SyntaxKind.EqualsGreaterThanToken
-                                ),
-                                factory.createPropertyAccessExpression(
-                                  factory.createIdentifier('result'),
-                                  factory.createIdentifier('data')
-                                )
-                              ),
-                            ]
-                          )
-                        )
+                        createCombineFunction(factory)
                       ),
                       factory.createPropertyAssignment(
                         factory.createIdentifier('queries'),
-                        factory.createArrayLiteralExpression(
-                          [
-                            factory.createObjectLiteralExpression(
-                              createOperationMethodParametersExampleNodes(
-                                operation,
-                                (parameter) => camelcase(`${parameter.name}-1`)
-                              ),
-                              true
-                            ),
-                            factory.createObjectLiteralExpression(
-                              createOperationMethodParametersExampleNodes(
-                                operation,
-                                (parameter) => camelcase(`${parameter.name}-2`)
-                              ),
-                              true
-                            ),
-                          ],
-                          true
-                        )
+                        createQueriesArrayExpression(operation, factory)
                       ),
                     ],
                     true
@@ -238,49 +101,9 @@ export const createUseQueriesOperationTSDocExample = (
           ts.NodeFlags.Const
         )
       ),
-      factory.createExpressionStatement(
-        factory.createCallExpression(
-          factory.createPropertyAccessExpression(
-            factory.createIdentifier(
-              camelcase(operation.name + '-combined-results')
-            ),
-            factory.createIdentifier('forEach')
-          ),
-          undefined,
-          [
-            factory.createArrowFunction(
-              undefined,
-              undefined,
-              [
-                factory.createParameterDeclaration(
-                  undefined,
-                  undefined,
-                  factory.createIdentifier('data')
-                ),
-              ],
-              undefined,
-              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-              factory.createCallExpression(
-                factory.createPropertyAccessExpression(
-                  factory.createIdentifier('console'),
-                  factory.createIdentifier('log')
-                ),
-                undefined,
-                [
-                  factory.createObjectLiteralExpression(
-                    [
-                      factory.createShorthandPropertyAssignment(
-                        factory.createIdentifier('data'),
-                        undefined
-                      ),
-                    ],
-                    false
-                  ),
-                ]
-              )
-            ),
-          ]
-        )
+      createCombinedResultsForEachExpression(
+        camelcase(operation.name + '-combined-results'),
+        factory
       ),
     ])
       .trim()
@@ -289,4 +112,187 @@ export const createUseQueriesOperationTSDocExample = (
   ];
 
   return example;
+};
+
+export const createQueriesArrayExpression = (
+  operation: ServiceOperation,
+  factory: ts.NodeFactory
+): ts.ArrayLiteralExpression => {
+  return factory.createArrayLiteralExpression(
+    [
+      factory.createObjectLiteralExpression(
+        createOperationMethodParametersExampleNodes(operation, (parameter) =>
+          camelcase(`${parameter.name}-1`)
+        ),
+        true
+      ),
+      factory.createObjectLiteralExpression(
+        createOperationMethodParametersExampleNodes(operation, (parameter) =>
+          camelcase(`${parameter.name}-2`)
+        ),
+        true
+      ),
+    ],
+    true
+  );
+};
+
+export const createCombineFunction = (
+  factory: ts.NodeFactory
+): ts.ArrowFunction => {
+  return factory.createArrowFunction(
+    undefined,
+    undefined,
+    [
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        factory.createIdentifier('results')
+      ),
+    ],
+    undefined,
+    factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+    factory.createCallExpression(
+      factory.createPropertyAccessExpression(
+        factory.createIdentifier('results'),
+        factory.createIdentifier('map')
+      ),
+      undefined,
+      [
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              factory.createIdentifier('result')
+            ),
+          ],
+          undefined,
+          factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          factory.createPropertyAccessExpression(
+            factory.createIdentifier('result'),
+            factory.createIdentifier('data')
+          )
+        ),
+      ]
+    )
+  );
+};
+
+export const createResultsForEachExpression = (
+  variableName: string,
+  factory: ts.NodeFactory
+): ts.ExpressionStatement => {
+  return factory.createExpressionStatement(
+    factory.createCallExpression(
+      factory.createPropertyAccessExpression(
+        factory.createIdentifier(variableName),
+        factory.createIdentifier('forEach')
+      ),
+      undefined,
+      [
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              factory.createObjectBindingPattern([
+                factory.createBindingElement(
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('isSuccess')
+                ),
+                factory.createBindingElement(
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('data')
+                ),
+                factory.createBindingElement(
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('error')
+                ),
+              ])
+            ),
+          ],
+          undefined,
+          factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(
+              factory.createIdentifier('console'),
+              factory.createIdentifier('log')
+            ),
+            undefined,
+            [
+              factory.createObjectLiteralExpression(
+                [
+                  factory.createShorthandPropertyAssignment(
+                    factory.createIdentifier('isSuccess')
+                  ),
+                  factory.createShorthandPropertyAssignment(
+                    factory.createIdentifier('data')
+                  ),
+                  factory.createShorthandPropertyAssignment(
+                    factory.createIdentifier('error')
+                  ),
+                ],
+                false
+              ),
+            ]
+          )
+        ),
+      ]
+    )
+  );
+};
+
+export const createCombinedResultsForEachExpression = (
+  variableName: string,
+  factory: ts.NodeFactory
+): ts.ExpressionStatement => {
+  return factory.createExpressionStatement(
+    factory.createCallExpression(
+      factory.createPropertyAccessExpression(
+        factory.createIdentifier(variableName),
+        factory.createIdentifier('forEach')
+      ),
+      undefined,
+      [
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              factory.createIdentifier('data')
+            ),
+          ],
+          undefined,
+          factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(
+              factory.createIdentifier('console'),
+              factory.createIdentifier('log')
+            ),
+            undefined,
+            [
+              factory.createObjectLiteralExpression(
+                [
+                  factory.createShorthandPropertyAssignment(
+                    factory.createIdentifier('data')
+                  ),
+                ],
+                false
+              ),
+            ]
+          )
+        ),
+      ]
+    )
+  );
 };

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseSuspenseQueriesOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseSuspenseQueriesOperationTSDocExample.ts
@@ -1,0 +1,121 @@
+import type { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
+import camelcase from 'camelcase';
+import ts from 'typescript';
+import { createOperationCommonTSDoc } from '../../lib/createOperationCommonTSDoc.js';
+import { astToString } from '../astToString.js';
+import {
+  createCombinedResultsForEachExpression,
+  createCombineFunction,
+  createQueriesArrayExpression,
+  createResultsForEachExpression,
+} from './createUseQueriesOperationTSDocExample.js';
+import { createOperationMethodCallExpressionExampleNode } from './lib/createOperationMethodCallExpressionExampleNode.js';
+
+export const createUseSuspenseQueriesOperationTSDocExample = (
+  operation: ServiceOperation,
+  serviceVariableName: string
+) => {
+  const factory = ts.factory;
+
+  const example: string[] = [
+    'Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.',
+    'Similar to useQueries but integrates with React Suspense for loading states.',
+    '',
+    ...createOperationCommonTSDoc(operation),
+    '@see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQueries|`useSuspenseQueries(...)` documentation}',
+
+    '@example Basic usage with Suspense',
+    '```ts',
+    ...astToString([
+      factory.createVariableStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              factory.createIdentifier(camelcase(operation.name + '-data')),
+              undefined,
+              undefined,
+              createOperationMethodCallExpressionExampleNode(
+                operation,
+                {
+                  serviceVariableName,
+                  operationMethodName: 'useSuspenseQueries',
+                },
+                [
+                  factory.createObjectLiteralExpression(
+                    [
+                      factory.createPropertyAssignment(
+                        factory.createIdentifier('queries'),
+                        createQueriesArrayExpression(operation, factory)
+                      ),
+                    ],
+                    true
+                  ),
+                ]
+              )
+            ),
+          ],
+          ts.NodeFlags.Const
+        )
+      ),
+      createResultsForEachExpression(
+        camelcase(operation.name + '-results'),
+        factory
+      ),
+    ])
+      .trim()
+      .split('\n'),
+    '```',
+
+    '@example With data transformation using combine',
+    '```ts',
+    ...astToString([
+      factory.createVariableStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              factory.createIdentifier(
+                camelcase(operation.name + '-combined-data')
+              ),
+              undefined,
+              undefined,
+              createOperationMethodCallExpressionExampleNode(
+                operation,
+                {
+                  serviceVariableName,
+                  operationMethodName: 'useSuspenseQueries',
+                },
+                [
+                  factory.createObjectLiteralExpression(
+                    [
+                      factory.createPropertyAssignment(
+                        factory.createIdentifier('combine'),
+                        createCombineFunction(factory)
+                      ),
+                      factory.createPropertyAssignment(
+                        factory.createIdentifier('queries'),
+                        createQueriesArrayExpression(operation, factory)
+                      ),
+                    ],
+                    true
+                  ),
+                ]
+              )
+            ),
+          ],
+          ts.NodeFlags.Const
+        )
+      ),
+      createCombinedResultsForEachExpression(
+        camelcase(operation.name + '-combined-data'),
+        factory
+      ),
+    ])
+      .trim()
+      .split('\n'),
+    '```',
+  ];
+
+  return example;
+};

--- a/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseSuspenseQueryOperationTSDocExample.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/tsdoc/createUseSuspenseQueryOperationTSDocExample.ts
@@ -1,0 +1,77 @@
+import { ServiceOperation } from '@openapi-qraft/plugin/lib/open-api/OpenAPIService';
+import ts from 'typescript';
+import { createOperationCommonTSDoc } from '../../lib/createOperationCommonTSDoc.js';
+import { astToString } from '../astToString.js';
+import { createOperationMethodCallExpressionExampleNode } from './lib/createOperationMethodCallExpressionExampleNode.js';
+import { createOperationMethodParametersExampleNodes } from './lib/createOperationMethodParametersExampleNodes.js';
+
+export const createUseSuspenseQueryOperationTSDocExample = (
+  operation: ServiceOperation,
+  serviceVariableName: string
+) => {
+  const example: string[] = [
+    'Performs asynchronous data fetching with Suspense support.',
+    'Similar to useQuery but integrates with React Suspense for loading states.',
+    '',
+    ...createOperationCommonTSDoc(operation),
+    '@see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQuery|`useSuspenseQuery(...)` documentation}',
+  ];
+
+  if (
+    !operation.parameters?.length ||
+    operation.parameters.every((parameter) => !parameter.required)
+  ) {
+    example.push(
+      '@example Suspense Query without parameters',
+      '```ts',
+      ...(
+        'const data = ' +
+        astToString(
+          createOperationMethodCallExpressionExampleNode(
+            operation,
+            {
+              serviceVariableName,
+              operationMethodName: 'useSuspenseQuery',
+            },
+            undefined
+          )
+        )
+      )
+        .trim()
+        .split('\n'),
+      '```'
+    );
+  }
+
+  if (operation.parameters?.length) {
+    const factory = ts.factory;
+
+    example.push(
+      '@example Suspense Query with parameters',
+      '```ts',
+      ...(
+        'const data = ' +
+        astToString(
+          createOperationMethodCallExpressionExampleNode(
+            operation,
+            {
+              serviceVariableName,
+              operationMethodName: 'useSuspenseQuery',
+            },
+            [
+              factory.createObjectLiteralExpression(
+                createOperationMethodParametersExampleNodes(operation),
+                true
+              ),
+            ]
+          )
+        )
+      )
+        .trim()
+        .split('\n'),
+      '```'
+    );
+  }
+
+  return example;
+};


### PR DESCRIPTION
Added TSDoc `@example` generation for the following hooks:

- `useSuspenseQuery`
- `useSuspenseQueries`

This provides clear usage examples in the generated API client.