### PR TITLE
fix(283): handle Primitive Methods (`toString`, `toJSON`) in API Client

### DIFF
--- a/.changeset/long-geckos-compare.md
+++ b/.changeset/long-geckos-compare.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': minor
+---
+
+Handle primitive methods (toString, toJSON, etc.) in API client to avoid implicit errors.

--- a/packages/react-client/src/lib/createRecursiveProxy.ts
+++ b/packages/react-client/src/lib/createRecursiveProxy.ts
@@ -1,11 +1,16 @@
-type ProxyApplyCallback = (path: string[], args: unknown[]) => unknown;
+type ProxyApplyCallback = (
+  path: (string | symbol)[],
+  args: unknown[]
+) => unknown;
 /**
  * @internal
  * If returns `undefined | null`, the proxy will continue to create a new proxy for the next key.
  */
-type ProxyGetCallback = (path: string[], key: string) => unknown | undefined;
+type ProxyGetCallback = (
+  path: (string | symbol)[],
+  key: string | symbol
+) => unknown | undefined;
 
-// todo::rename to `qraftRecursiveProxy` with deprecated `createRecursiveProxy`
 /**
  * Creates a recursive proxy that calls the `getCallback` and `applyCallback` functions
  * @param getCallback The callback to call when a proxy property is accessed
@@ -15,11 +20,11 @@ type ProxyGetCallback = (path: string[], key: string) => unknown | undefined;
 export function createRecursiveProxy(
   getCallback: ProxyGetCallback,
   applyCallback: ProxyApplyCallback,
-  path: string[]
+  path: (string | symbol)[]
 ): unknown {
   return new Proxy(noop, {
     get(_obj, key) {
-      if (typeof key !== 'string' || key === 'then') {
+      if (key === 'then') {
         // special case for if the proxy is accidentally treated
         // like a PromiseLike (like in `Promise.resolve(proxy)`)
         return undefined;

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -20,7 +20,7 @@ import {
 } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { qraftAPIClient, requestFn } from '../index.js';
 import { createPredefinedParametersRequestFn } from './fixtures/api/create-predefined-parameters-request-fn.js';
 import { createAPIClient, services } from './fixtures/api/index.js';
@@ -4504,6 +4504,158 @@ describe('Qraft is type-safe if client created with "QueryClient" only', () => {
       // @ts-expect-error - no options provided for the request - must emit an error
       qraft.files.findAll.fetchQuery()
     ).rejects.toThrow();
+  });
+});
+
+describe('Qraft API Client primitive conversions', () => {
+  let qraft: ReturnType<typeof createAPIClient>;
+
+  beforeEach(() => {
+    qraft = createAPIClient({ queryClient: new QueryClient() });
+  });
+
+  describe('Root level conversions', () => {
+    it('should handle string conversion', () => {
+      expect(String(qraft)).toBe(qraft.toString());
+      expect(`${qraft}`).toBe(qraft.toString());
+    });
+
+    it('should handle number conversion', () => {
+      expect(Number(qraft)).toBeNaN();
+      expect(+qraft).toBeNaN();
+    });
+
+    it('should handle JSON serialization', () => {
+      expect(JSON.stringify(qraft)).toBe(
+        JSON.stringify(JSON.stringify(services))
+      );
+    });
+
+    it('toJSON() returns JSON string', () => {
+      expect(
+        // @ts-expect-error - toJSON() is not a standard method for Qraft API Client
+        qraft.toJSON()
+      ).toBe(JSON.stringify(services));
+    });
+
+    it('should handle valueOf()', () => {
+      const value = qraft.valueOf();
+      expect(typeof value).toBe('object');
+      expect(value).toBe(services);
+    });
+
+    it('should handle Symbol.toStringTag', () => {
+      expect(Object.prototype.toString.call(qraft)).toBe(
+        '[object QraftAPIClient]'
+      );
+    });
+  });
+
+  describe('Service level conversions', () => {
+    it('should handle string conversion', () => {
+      expect(String(qraft.approvalPolicies)).toBe(
+        qraft.approvalPolicies.toString()
+      );
+      expect(`${qraft.approvalPolicies}`).toBe(
+        qraft.approvalPolicies.toString()
+      );
+    });
+
+    it('should handle number conversion', () => {
+      expect(Number(qraft.approvalPolicies)).toBeNaN();
+      expect(+qraft.approvalPolicies).toBeNaN();
+    });
+
+    it('should handle JSON serialization', () => {
+      expect(JSON.stringify(qraft.approvalPolicies)).toBe(
+        JSON.stringify(JSON.stringify(services.approvalPolicies))
+      );
+    });
+
+    it('should handle valueOf()', () => {
+      const value = qraft.approvalPolicies.valueOf();
+      expect(typeof value).toBe('object');
+      expect(value).toBe(qraft.approvalPolicies.valueOf());
+    });
+
+    it('should handle Symbol.toStringTag', () => {
+      expect(Object.prototype.toString.call(qraft.approvalPolicies)).toBe(
+        '[object QraftAPIClient]'
+      );
+    });
+  });
+
+  describe('Operation level conversions', () => {
+    it('should handle string conversion', () => {
+      expect(String(qraft.approvalPolicies.getApprovalPoliciesId)).toBe(
+        qraft.approvalPolicies.getApprovalPoliciesId.toString()
+      );
+    });
+
+    it('should handle number conversion', () => {
+      expect(Number(qraft.approvalPolicies.getApprovalPoliciesId)).toBeNaN();
+    });
+
+    it('should handle JSON serialization', () => {
+      expect(JSON.stringify(qraft.approvalPolicies.getApprovalPoliciesId)).toBe(
+        JSON.stringify(
+          JSON.stringify(services.approvalPolicies.getApprovalPoliciesId)
+        )
+      );
+    });
+
+    it('should handle valueOf()', () => {
+      const value = qraft.approvalPolicies.getApprovalPoliciesId.valueOf();
+      expect(typeof value).toBe('object');
+    });
+
+    it('should handle Symbol.toStringTag', () => {
+      expect(
+        Object.prototype.toString.call(
+          qraft.approvalPolicies.getApprovalPoliciesId
+        )
+      ).toBe('[object QraftAPIClient]');
+    });
+  });
+});
+
+describe('Qraft API Client console logging', () => {
+  let qraft: ReturnType<typeof createAPIClient>;
+
+  beforeEach(() => {
+    qraft = createAPIClient({ queryClient: new QueryClient() });
+  });
+
+  describe('Individual elements logging', () => {
+    it('should log root client without errors', () => {
+      expect(() => console.log(qraft)).not.toThrow();
+    });
+
+    it('should log service without errors', () => {
+      expect(() => console.log(qraft.approvalPolicies)).not.toThrow();
+    });
+
+    it('should log operation without errors', () => {
+      expect(() =>
+        console.log(qraft.approvalPolicies.getApprovalPoliciesId)
+      ).not.toThrow();
+    });
+  });
+
+  describe('Multiple levels mixed logging', () => {
+    it('should log multiple client elements without errors', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      try {
+        console.log('Client:', qraft);
+        console.log('Service:', qraft.approvalPolicies);
+        console.log('Operation:', qraft.approvalPolicies.getApprovalPoliciesId);
+
+        expect(consoleSpy).toHaveBeenCalledTimes(3);
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## What was done
- Implemented handling for primitive methods (e.g., `toString`, `toJSON`, etc.) during API client usage.
- Included minor refactors and additional improvements beyond the original issue scope.
