### PR TITLE
refactor: use schema type references instead of inline definitions

### DIFF
--- a/.changeset/bumpy-ravens-yawn.md
+++ b/.changeset/bumpy-ravens-yawn.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+---
+
+Simplified the generated code by replacing inlined `schema` types with references to named types where applicable.

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -901,42 +901,21 @@ export const approvalPoliciesService: {
      * @description Retrieve a specific approval policy.
      */
     getApprovalPoliciesId: {
-        schema: {
-            method: "get";
-            url: "/approval_policies/{approval_policy_id}";
-            security: [
-                "partnerToken"
-            ];
-        };
+        schema: GetApprovalPoliciesIdSchema;
     };
     /**
      * @summary Delete an approval policy
      * @description Delete an existing approval policy.
      */
     deleteApprovalPoliciesId: {
-        schema: {
-            method: "delete";
-            url: "/approval_policies/{approval_policy_id}";
-            security: [
-                "HTTPBearer"
-            ];
-        };
+        schema: DeleteApprovalPoliciesIdSchema;
     };
     /**
      * @summary Update an approval policy
      * @description Update an existing approval policy.
      */
     patchApprovalPoliciesId: {
-        schema: {
-            method: "patch";
-            url: "/approval_policies/{approval_policy_id}";
-            mediaType: [
-                "application/json"
-            ];
-            security: [
-                "HTTPBearer"
-            ];
-        };
+        schema: PatchApprovalPoliciesIdSchema;
     };
 } = {
     getApprovalPoliciesId: {

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -1107,43 +1107,22 @@ export interface FilesService {
 export const filesService: {
     /** @summary Get a files by ID */
     getFiles: {
-        schema: {
-            method: "get";
-            url: "/files";
-            security: [
-                "HTTPBearer"
-            ];
-        };
+        schema: GetFilesSchema;
     };
     /** @summary Upload a files by ID */
     postFiles: {
-        schema: {
-            method: "post";
-            url: "/files";
-            mediaType: [
-                "multipart/form-data"
-            ];
-        };
+        schema: PostFilesSchema;
     };
     /** @summary Delete all files */
     deleteFiles: {
-        schema: {
-            method: "delete";
-            url: "/files";
-        };
+        schema: DeleteFilesSchema;
     };
     /**
      * @deprecated
      * @summary Get a file list
      */
     getFileList: {
-        schema: {
-            method: "get";
-            url: "/files/list";
-            security: [
-                "HTTPBearer"
-            ];
-        };
+        schema: GetFileListSchema;
     };
 } = {
     getFiles: {

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -529,7 +529,7 @@ const getServiceVariableTypeFactory = (operation: ServiceOperation) => {
         undefined,
         factory.createIdentifier('schema'),
         undefined,
-        getOperationSchemaFactory(operation)
+        factory.createTypeReferenceNode(getOperationSchemaTypeName(operation))
       ),
     ])
   );


### PR DESCRIPTION
Simplified the generated code by replacing inlined `schema` types with references to named types where applicable.