### PR TITLE
feat: allow read-only objects to be passed as query or body parameters

### DIFF
--- a/.changeset/silver-beds-float.md
+++ b/.changeset/silver-beds-float.md
@@ -1,0 +1,6 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/tanstack-query-react-types': patch
+---
+
+Allow read-only objects to be used as query and body parameters in client methods.

--- a/packages/react-client/src/tests/createAPIClient.const-parameters.types-test.ts
+++ b/packages/react-client/src/tests/createAPIClient.const-parameters.types-test.ts
@@ -1,0 +1,155 @@
+import { QueryClient } from '@tanstack/query-core';
+import { requestFn } from '../index.js';
+import { createAPIClient } from './fixtures/api/index.js';
+
+const qraft = createAPIClient({
+  queryClient: new QueryClient(),
+  requestFn: requestFn,
+  baseUrl: 'https://example.com',
+});
+
+{
+  // Normal inline parameters
+  qraft.files.getFiles.setQueryData(
+    {
+      query: { id__in: ['1', '2'] },
+      header: {
+        'x-monite-version': 'current',
+      },
+    },
+    { query: { id__in: ['1'] } }
+  );
+
+  qraft.files.getFiles.getQueryData({
+    query: { id__in: ['1'] },
+    header: {
+      'x-monite-version': 'current',
+    },
+  });
+}
+
+{
+  // Const inline parameters
+  qraft.files.getFiles.setQueryData(
+    {
+      query: { id__in: ['1', '2'] },
+      header: {
+        'x-monite-version': 'current',
+      },
+    } as const,
+    { query: { id__in: ['1'] } } as const
+  );
+
+  qraft.files.getFiles.getQueryData({
+    query: { id__in: ['1'] },
+    header: {
+      'x-monite-version': 'current',
+    },
+  } as const);
+}
+
+{
+  // External mutable parameters
+  const parameters = {
+    query: { id__in: ['1', '2'] },
+    header: {
+      'x-monite-version': 'current',
+    },
+  };
+
+  const data = { query: { id__in: ['1'] } };
+
+  qraft.files.getFiles.setQueryData(parameters, data);
+  qraft.files.getFiles.setInfiniteQueryData(parameters, (pages) => ({
+    pages: [...(pages?.pages ?? []), data],
+    pageParams: [...(pages?.pageParams ?? []), {}],
+  }));
+  qraft.files.getFiles.getQueryData(parameters);
+  qraft.files.getFiles.useQuery(parameters);
+  qraft.files.getFiles.useInfiniteQuery(parameters, {
+    initialPageParam: {},
+    getNextPageParam: () => undefined,
+  });
+  void qraft.files.getFiles.fetchQuery({ parameters });
+  void qraft.files.getFiles.fetchInfiniteQuery({
+    parameters,
+    initialPageParam: {},
+    getNextPageParam: () => undefined,
+  });
+  void qraft.files.getFiles({ parameters });
+}
+
+{
+  // External const parameters
+  const parameters = {
+    query: { id__in: ['1', '2'] },
+    header: {
+      'x-monite-version': 'current',
+    },
+  } as const;
+
+  const data = { query: { id__in: ['1'] } } as const;
+
+  qraft.files.getFiles.setQueryData(parameters, data);
+  qraft.files.getFiles.setInfiniteQueryData(parameters, (pages) => ({
+    pages: [...(pages?.pages ?? []), data],
+    pageParams: [...(pages?.pageParams ?? []), {}],
+  }));
+  qraft.files.getFiles.getQueryData(parameters);
+  qraft.files.getFiles.useQuery(parameters);
+  qraft.files.getFiles.useInfiniteQuery(parameters, {
+    initialPageParam: {},
+    getNextPageParam: () => undefined,
+  });
+  void qraft.files.getFiles.fetchQuery({ parameters });
+  void qraft.files.getFiles.fetchInfiniteQuery({
+    parameters,
+    initialPageParam: {},
+    getNextPageParam: () => undefined,
+  });
+  void qraft.files.getFiles({ parameters });
+}
+
+{
+  // External const parameters for useMutation
+  const parameters = { query: { all: true } } as const;
+  qraft.files.deleteFiles.useMutation(parameters);
+  void qraft.files.deleteFiles({ parameters });
+}
+
+{
+  // Incorrect usage
+  qraft.files.getFiles.setQueryData(
+    {
+      // @ts-expect-error - OK, incorrect usage
+      query: { id__in: [1, 2] },
+      header: {
+        // @ts-expect-error - OK, incorrect usage
+        'x-monite-version': true,
+      },
+    },
+    { query: { id__in: ['1'] } }
+  );
+  qraft.files.getFiles.getQueryData({
+    // @ts-expect-error - OK, incorrect usage
+    query: { id__in: [1, 2] },
+    header: {
+      // @ts-expect-error - OK, incorrect usage
+      'x-monite-version': true,
+    },
+  });
+  qraft.files.getFiles.setQueryData(
+    {
+      query: { id__in: ['1', '2'] },
+      header: {
+        'x-monite-version': 'current',
+      },
+    } as const,
+    {
+      query: {
+        // @ts-expect-error - OK, incorrect usage
+        id__in: [1],
+      },
+    } as const
+  );
+}

--- a/packages/tanstack-query-react-plugin/package.json
+++ b/packages/tanstack-query-react-plugin/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@openapi-qraft/eslint-config": "workspace:*",
+    "@openapi-qraft/tanstack-query-react-types": "workspace:*",
     "@openapi-qraft/test-fixtures": "workspace:*",
     "@openapi-qraft/ts-factory-code-generator": "workspace:*",
     "camelcase": "^8.0.0",

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/ApprovalPoliciesService.ts.snapshot.ts
@@ -4,7 +4,7 @@
  */
 
 import type { paths } from "../../openapi.js";
-import type { AreAllOptional, InvalidateQueryFilters, MutationFiltersByMutationKey, MutationFiltersByParameters, MutationVariables, OperationInfiniteData, PartialParameters, QueryFiltersByParameters, QueryFiltersByQueryKey, QueryFnOptionsByParameters, QueryFnOptionsByQueryKey, RequestFnResponse, ServiceOperationEnsureInfiniteQueryDataOptions, ServiceOperationEnsureQueryDataOptions, ServiceOperationFetchInfiniteQueryOptions, ServiceOperationFetchQueryOptions, ServiceOperationInfiniteQueryKey, ServiceOperationMutationFnOptions, ServiceOperationMutationKey, ServiceOperationQueryKey, ServiceOperationUseMutationOptions, UseQueryOptionsForUseQueries, UseQueryOptionsForUseSuspenseQuery, WithOptional } from "@openapi-qraft/tanstack-query-react-types";
+import type { AreAllOptional, DeepReadonly, InvalidateQueryFilters, MutationFiltersByMutationKey, MutationFiltersByParameters, MutationVariables, OperationInfiniteData, PartialParameters, QueryFiltersByParameters, QueryFiltersByQueryKey, QueryFnOptionsByParameters, QueryFnOptionsByQueryKey, RequestFnResponse, ServiceOperationEnsureInfiniteQueryDataOptions, ServiceOperationEnsureQueryDataOptions, ServiceOperationFetchInfiniteQueryOptions, ServiceOperationFetchQueryOptions, ServiceOperationInfiniteQueryKey, ServiceOperationMutationFnOptions, ServiceOperationMutationKey, ServiceOperationQueryKey, ServiceOperationUseMutationOptions, UseQueryOptionsForUseQueries, UseQueryOptionsForUseSuspenseQuery, WithOptional } from "@openapi-qraft/tanstack-query-react-types";
 import type { CancelOptions, InfiniteQueryPageParamsOptions, InvalidateOptions, Mutation, MutationState, NoInfer, QueryState, RefetchOptions, ResetOptions, SetDataOptions, Updater } from "@tanstack/query-core";
 import type { DefinedInitialDataInfiniteOptions, DefinedInitialDataOptions, DefinedUseInfiniteQueryResult, DefinedUseQueryResult, UndefinedInitialDataInfiniteOptions, UndefinedInitialDataOptions, UseInfiniteQueryResult, UseMutationResult, UseQueryResult, UseSuspenseInfiniteQueryOptions, UseSuspenseInfiniteQueryResult, UseSuspenseQueryOptions, UseSuspenseQueryResult } from "@tanstack/react-query";
 export interface ApprovalPoliciesService {
@@ -22,7 +22,7 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getQueryKey(parameters: GetApprovalPoliciesIdParameters): ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>;
+        getQueryKey(parameters: DeepReadonly<GetApprovalPoliciesIdParameters>): ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -45,7 +45,7 @@ export interface ApprovalPoliciesService {
          * })
          * ```
          */
-        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options?: Omit<UndefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options?: Omit<UndefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -68,7 +68,7 @@ export interface ApprovalPoliciesService {
          * })
          * ```
          */
-        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options: Omit<DefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options: Omit<DefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
@@ -103,7 +103,7 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters)): OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters> | undefined;
+        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>)): OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters> | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
@@ -119,17 +119,17 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getQueryData(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters)): GetApprovalPoliciesIdData | undefined;
+        getQueryData(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>)): GetApprovalPoliciesIdData | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getQueryState(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters)): QueryState<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError> | undefined;
+        getQueryState(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>)): QueryState<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError> | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getInfiniteQueryState(parameters: GetApprovalPoliciesIdParameters | ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>): QueryState<OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdError> | undefined;
+        getInfiniteQueryState(parameters: DeepReadonly<GetApprovalPoliciesIdParameters> | ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>): QueryState<OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdError> | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
@@ -168,7 +168,7 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        setInfiniteQueryData(parameters: GetApprovalPoliciesIdParameters | ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, updater: Updater<NoInfer<OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters>> | undefined, NoInfer<OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters>> | undefined>, options?: SetDataOptions): OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters> | undefined;
+        setInfiniteQueryData(parameters: (DeepReadonly<GetApprovalPoliciesIdParameters>) | ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, updater: Updater<NoInfer<OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters>> | undefined, NoInfer<DeepReadonly<OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters>>> | undefined>, options?: SetDataOptions): OperationInfiniteData<GetApprovalPoliciesIdData, GetApprovalPoliciesIdParameters> | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
@@ -178,12 +178,12 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        setQueryData(parameters: (GetApprovalPoliciesIdParameters) | ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, updater: Updater<NoInfer<GetApprovalPoliciesIdData> | undefined, NoInfer<GetApprovalPoliciesIdData> | undefined>, options?: SetDataOptions): GetApprovalPoliciesIdData | undefined;
+        setQueryData(parameters: (DeepReadonly<GetApprovalPoliciesIdParameters>) | ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, updater: Updater<NoInfer<GetApprovalPoliciesIdData> | undefined, NoInfer<DeepReadonly<GetApprovalPoliciesIdData>> | undefined>, options?: SetDataOptions): GetApprovalPoliciesIdData | undefined;
         /**
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getInfiniteQueryKey(parameters: GetApprovalPoliciesIdParameters): ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>;
+        getInfiniteQueryKey(parameters: DeepReadonly<GetApprovalPoliciesIdParameters>): ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -213,7 +213,7 @@ export interface ApprovalPoliciesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TQueryFnData = GetApprovalPoliciesIdData, TData = OperationInfiniteData<TQueryFnData, GetApprovalPoliciesIdParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, GetApprovalPoliciesIdError, TData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<TPageParam>>): UseInfiniteQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TQueryFnData = GetApprovalPoliciesIdData, TData = OperationInfiniteData<TQueryFnData, GetApprovalPoliciesIdParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, GetApprovalPoliciesIdError, TData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<TPageParam>>): UseInfiniteQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -243,7 +243,7 @@ export interface ApprovalPoliciesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TQueryFnData = GetApprovalPoliciesIdData, TData = OperationInfiniteData<TQueryFnData, GetApprovalPoliciesIdParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, GetApprovalPoliciesIdError, TData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetApprovalPoliciesIdData, PartialParameters<TPageParam>>): DefinedUseInfiniteQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TQueryFnData = GetApprovalPoliciesIdData, TData = OperationInfiniteData<TQueryFnData, GetApprovalPoliciesIdParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, GetApprovalPoliciesIdError, TData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetApprovalPoliciesIdData, PartialParameters<TPageParam>>): DefinedUseInfiniteQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         /**
          * Monitors the number of queries currently fetching, matching the provided filters.
          * Useful for creating loading indicators or performing actions based on active requests.
@@ -354,7 +354,7 @@ export interface ApprovalPoliciesService {
          * @summary Get an approval policy by ID
          * @description Retrieve a specific approval policy.
          */
-        getQueryKey(parameters: GetApprovalPoliciesIdParameters): ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>;
+        getQueryKey(parameters: DeepReadonly<GetApprovalPoliciesIdParameters>): ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -377,7 +377,7 @@ export interface ApprovalPoliciesService {
          * })
          * ```
          */
-        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options?: Omit<UndefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options?: Omit<UndefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -400,7 +400,7 @@ export interface ApprovalPoliciesService {
          * })
          * ```
          */
-        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options: Omit<DefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options: Omit<DefinedInitialDataOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -431,7 +431,7 @@ export interface ApprovalPoliciesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useSuspenseInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options: Omit<UseSuspenseInfiniteQueryOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, OperationInfiniteData<TData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetApprovalPoliciesIdData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdError | Error>;
+        useSuspenseInfiniteQuery<TPageParam extends GetApprovalPoliciesIdParameters, TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options: Omit<UseSuspenseInfiniteQueryOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, OperationInfiniteData<TData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdData, ServiceOperationInfiniteQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetApprovalPoliciesIdData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetApprovalPoliciesIdParameters>, GetApprovalPoliciesIdError | Error>;
         /**
          * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
          * Similar to useQueries but integrates with React Suspense for loading states.
@@ -532,7 +532,7 @@ export interface ApprovalPoliciesService {
          * })
          * ```
          */
-        useSuspenseQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (GetApprovalPoliciesIdParameters), options?: Omit<UseSuspenseQueryOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
+        useSuspenseQuery<TData = GetApprovalPoliciesIdData>(parameters: ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters> | (DeepReadonly<GetApprovalPoliciesIdParameters>), options?: Omit<UseSuspenseQueryOptions<GetApprovalPoliciesIdData, GetApprovalPoliciesIdError, TData, ServiceOperationQueryKey<GetApprovalPoliciesIdSchema, GetApprovalPoliciesIdParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetApprovalPoliciesIdError | Error>;
         schema: GetApprovalPoliciesIdSchema;
         types: {
             parameters: GetApprovalPoliciesIdParameters;
@@ -549,7 +549,7 @@ export interface ApprovalPoliciesService {
          * @summary Delete an approval policy
          * @description Delete an existing approval policy.
          */
-        getMutationKey(parameters: DeleteApprovalPoliciesIdParameters | void): ServiceOperationMutationKey<DeleteApprovalPoliciesIdSchema, DeleteApprovalPoliciesIdParameters>;
+        getMutationKey(parameters: DeepReadonly<DeleteApprovalPoliciesIdParameters> | void): ServiceOperationMutationKey<DeleteApprovalPoliciesIdSchema, DeleteApprovalPoliciesIdParameters>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -589,7 +589,7 @@ export interface ApprovalPoliciesService {
          * });
          * ```
          */
-        useMutation<TVariables extends DeleteApprovalPoliciesIdBody, TContext = unknown>(parameters: DeleteApprovalPoliciesIdParameters, options?: ServiceOperationUseMutationOptions<DeleteApprovalPoliciesIdSchema, DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdParameters, TVariables, DeleteApprovalPoliciesIdError | Error, TContext>): UseMutationResult<DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
+        useMutation<TVariables extends DeleteApprovalPoliciesIdBody, TContext = unknown>(parameters: DeepReadonly<DeleteApprovalPoliciesIdParameters>, options?: ServiceOperationUseMutationOptions<DeleteApprovalPoliciesIdSchema, DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdParameters, TVariables, DeleteApprovalPoliciesIdError | Error, TContext>): UseMutationResult<DeleteApprovalPoliciesIdData, DeleteApprovalPoliciesIdError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -726,7 +726,7 @@ export interface ApprovalPoliciesService {
          * @summary Update an approval policy
          * @description Update an existing approval policy.
          */
-        getMutationKey(parameters: PatchApprovalPoliciesIdParameters | void): ServiceOperationMutationKey<PatchApprovalPoliciesIdSchema, PatchApprovalPoliciesIdParameters>;
+        getMutationKey(parameters: DeepReadonly<PatchApprovalPoliciesIdParameters> | void): ServiceOperationMutationKey<PatchApprovalPoliciesIdSchema, PatchApprovalPoliciesIdParameters>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -766,7 +766,7 @@ export interface ApprovalPoliciesService {
          * });
          * ```
          */
-        useMutation<TVariables extends PatchApprovalPoliciesIdBody, TContext = unknown>(parameters: PatchApprovalPoliciesIdParameters, options?: ServiceOperationUseMutationOptions<PatchApprovalPoliciesIdSchema, PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdParameters, TVariables, PatchApprovalPoliciesIdError | Error, TContext>): UseMutationResult<PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
+        useMutation<TVariables extends PatchApprovalPoliciesIdBody, TContext = unknown>(parameters: DeepReadonly<PatchApprovalPoliciesIdParameters>, options?: ServiceOperationUseMutationOptions<PatchApprovalPoliciesIdSchema, PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdParameters, TVariables, PatchApprovalPoliciesIdError | Error, TContext>): UseMutationResult<PatchApprovalPoliciesIdData, PatchApprovalPoliciesIdError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -4,7 +4,7 @@
  */
 
 import type { paths } from "../../openapi.js";
-import type { AreAllOptional, InvalidateQueryFilters, MutationFiltersByMutationKey, MutationFiltersByParameters, MutationVariables, OperationInfiniteData, PartialParameters, QueryFiltersByParameters, QueryFiltersByQueryKey, QueryFnOptionsByParameters, QueryFnOptionsByQueryKey, RequestFnResponse, ServiceOperationEnsureInfiniteQueryDataOptions, ServiceOperationEnsureQueryDataOptions, ServiceOperationFetchInfiniteQueryOptions, ServiceOperationFetchQueryOptions, ServiceOperationInfiniteQueryKey, ServiceOperationMutationFnOptions, ServiceOperationMutationKey, ServiceOperationQueryKey, ServiceOperationUseMutationOptions, UseQueryOptionsForUseQueries, UseQueryOptionsForUseSuspenseQuery, WithOptional } from "@openapi-qraft/tanstack-query-react-types";
+import type { AreAllOptional, DeepReadonly, InvalidateQueryFilters, MutationFiltersByMutationKey, MutationFiltersByParameters, MutationVariables, OperationInfiniteData, PartialParameters, QueryFiltersByParameters, QueryFiltersByQueryKey, QueryFnOptionsByParameters, QueryFnOptionsByQueryKey, RequestFnResponse, ServiceOperationEnsureInfiniteQueryDataOptions, ServiceOperationEnsureQueryDataOptions, ServiceOperationFetchInfiniteQueryOptions, ServiceOperationFetchQueryOptions, ServiceOperationInfiniteQueryKey, ServiceOperationMutationFnOptions, ServiceOperationMutationKey, ServiceOperationQueryKey, ServiceOperationUseMutationOptions, UseQueryOptionsForUseQueries, UseQueryOptionsForUseSuspenseQuery, WithOptional } from "@openapi-qraft/tanstack-query-react-types";
 import type { CancelOptions, InfiniteQueryPageParamsOptions, InvalidateOptions, Mutation, MutationState, NoInfer, QueryState, RefetchOptions, ResetOptions, SetDataOptions, Updater } from "@tanstack/query-core";
 import type { DefinedInitialDataInfiniteOptions, DefinedInitialDataOptions, DefinedUseInfiniteQueryResult, DefinedUseQueryResult, UndefinedInitialDataInfiniteOptions, UndefinedInitialDataOptions, UseInfiniteQueryResult, UseMutationResult, UseQueryResult, UseSuspenseInfiniteQueryOptions, UseSuspenseInfiniteQueryResult, UseSuspenseQueryOptions, UseSuspenseQueryResult } from "@tanstack/react-query";
 export interface FilesService {
@@ -13,7 +13,7 @@ export interface FilesService {
         /** @summary Get a files by ID */
         cancelQueries<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError> | QueryFiltersByQueryKey<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError>, options?: CancelOptions): Promise<void>;
         /** @summary Get a files by ID */
-        getQueryKey(parameters: GetFilesParameters): ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>;
+        getQueryKey(parameters: DeepReadonly<GetFilesParameters>): ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -31,7 +31,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options?: Omit<UndefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseQueryResult<TData, GetFilesError | Error>;
+        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options?: Omit<UndefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseQueryResult<TData, GetFilesError | Error>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -49,7 +49,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options: Omit<DefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFilesError | Error>;
+        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options: Omit<DefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFilesError | Error>;
         /** @summary Get a files by ID */
         fetchInfiniteQuery<TPageParam extends GetFilesParameters>(options: ServiceOperationFetchInfiniteQueryOptions<GetFilesSchema, GetFilesData, GetFilesParameters, TPageParam, GetFilesError>): Promise<OperationInfiniteData<GetFilesData, GetFilesParameters>>;
         /** @summary Get a files by ID */
@@ -63,7 +63,7 @@ export interface FilesService {
         /** @summary Get a files by ID */
         ensureQueryData(options: ServiceOperationEnsureQueryDataOptions<GetFilesSchema, GetFilesData, GetFilesParameters, GetFilesError>): Promise<GetFilesData>;
         /** @summary Get a files by ID */
-        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters)): OperationInfiniteData<GetFilesData, GetFilesParameters> | undefined;
+        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>)): OperationInfiniteData<GetFilesData, GetFilesParameters> | undefined;
         /** @summary Get a files by ID */
         getQueriesData<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError> | QueryFiltersByQueryKey<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError>): TInfinite extends true ? Array<[
             queryKey: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>,
@@ -73,11 +73,11 @@ export interface FilesService {
             data: GetFilesData | undefined
         ]>;
         /** @summary Get a files by ID */
-        getQueryData(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters)): GetFilesData | undefined;
+        getQueryData(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>)): GetFilesData | undefined;
         /** @summary Get a files by ID */
-        getQueryState(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters)): QueryState<GetFilesData, GetFilesError> | undefined;
+        getQueryState(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>)): QueryState<GetFilesData, GetFilesError> | undefined;
         /** @summary Get a files by ID */
-        getInfiniteQueryState(parameters: GetFilesParameters | ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>): QueryState<OperationInfiniteData<GetFilesData, GetFilesParameters>, GetFilesError> | undefined;
+        getInfiniteQueryState(parameters: DeepReadonly<GetFilesParameters> | ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>): QueryState<OperationInfiniteData<GetFilesData, GetFilesParameters>, GetFilesError> | undefined;
         /** @summary Get a files by ID */
         invalidateQueries<TInfinite extends boolean = false>(filters?: InvalidateQueryFilters<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError>, options?: InvalidateOptions): Promise<void>;
         /** @summary Get a files by ID */
@@ -95,13 +95,13 @@ export interface FilesService {
         /** @summary Get a files by ID */
         resetQueries<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError> | QueryFiltersByQueryKey<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError>, options?: ResetOptions): Promise<void>;
         /** @summary Get a files by ID */
-        setInfiniteQueryData(parameters: GetFilesParameters | ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, updater: Updater<NoInfer<OperationInfiniteData<GetFilesData, GetFilesParameters>> | undefined, NoInfer<OperationInfiniteData<GetFilesData, GetFilesParameters>> | undefined>, options?: SetDataOptions): OperationInfiniteData<GetFilesData, GetFilesParameters> | undefined;
+        setInfiniteQueryData(parameters: (DeepReadonly<GetFilesParameters>) | ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, updater: Updater<NoInfer<OperationInfiniteData<GetFilesData, GetFilesParameters>> | undefined, NoInfer<DeepReadonly<OperationInfiniteData<GetFilesData, GetFilesParameters>>> | undefined>, options?: SetDataOptions): OperationInfiniteData<GetFilesData, GetFilesParameters> | undefined;
         /** @summary Get a files by ID */
         setQueriesData<TInfinite extends boolean = false>(filters: QueryFiltersByParameters<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError> | QueryFiltersByQueryKey<GetFilesSchema, GetFilesData, TInfinite, GetFilesParameters, GetFilesError>, updater: Updater<NoInfer<GetFilesData> | undefined, NoInfer<GetFilesData> | undefined>, options?: SetDataOptions): Array<GetFilesData | undefined>;
         /** @summary Get a files by ID */
-        setQueryData(parameters: (GetFilesParameters) | ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>, updater: Updater<NoInfer<GetFilesData> | undefined, NoInfer<GetFilesData> | undefined>, options?: SetDataOptions): GetFilesData | undefined;
+        setQueryData(parameters: (DeepReadonly<GetFilesParameters>) | ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>, updater: Updater<NoInfer<GetFilesData> | undefined, NoInfer<DeepReadonly<GetFilesData>> | undefined>, options?: SetDataOptions): GetFilesData | undefined;
         /** @summary Get a files by ID */
-        getInfiniteQueryKey(parameters: GetFilesParameters): ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>;
+        getInfiniteQueryKey(parameters: DeepReadonly<GetFilesParameters>): ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -130,7 +130,7 @@ export interface FilesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useInfiniteQuery<TPageParam extends GetFilesParameters, TQueryFnData = GetFilesData, TData = OperationInfiniteData<TQueryFnData, GetFilesParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, GetFilesError, TData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<TPageParam>>): UseInfiniteQueryResult<TData, GetFilesError | Error>;
+        useInfiniteQuery<TPageParam extends GetFilesParameters, TQueryFnData = GetFilesData, TData = OperationInfiniteData<TQueryFnData, GetFilesParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, GetFilesError, TData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<TPageParam>>): UseInfiniteQueryResult<TData, GetFilesError | Error>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -159,7 +159,7 @@ export interface FilesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useInfiniteQuery<TPageParam extends GetFilesParameters, TQueryFnData = GetFilesData, TData = OperationInfiniteData<TQueryFnData, GetFilesParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, GetFilesError, TData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFilesData, PartialParameters<TPageParam>>): DefinedUseInfiniteQueryResult<TData, GetFilesError | Error>;
+        useInfiniteQuery<TPageParam extends GetFilesParameters, TQueryFnData = GetFilesData, TData = OperationInfiniteData<TQueryFnData, GetFilesParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, GetFilesError, TData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFilesData, PartialParameters<TPageParam>>): DefinedUseInfiniteQueryResult<TData, GetFilesError | Error>;
         /**
          * Monitors the number of queries currently fetching, matching the provided filters.
          * Useful for creating loading indicators or performing actions based on active requests.
@@ -246,7 +246,7 @@ export interface FilesService {
             combine?: (results: Array<UseQueryResult<GetFilesData, GetFilesError>>) => TCombinedResult;
         }): TCombinedResult;
         /** @summary Get a files by ID */
-        getQueryKey(parameters: GetFilesParameters): ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>;
+        getQueryKey(parameters: DeepReadonly<GetFilesParameters>): ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -264,7 +264,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options?: Omit<UndefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseQueryResult<TData, GetFilesError | Error>;
+        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options?: Omit<UndefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseQueryResult<TData, GetFilesError | Error>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -282,7 +282,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options: Omit<DefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFilesError | Error>;
+        useQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options: Omit<DefinedInitialDataOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFilesError | Error>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -312,7 +312,7 @@ export interface FilesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useSuspenseInfiniteQuery<TPageParam extends GetFilesParameters, TData = GetFilesData>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options: Omit<UseSuspenseInfiniteQueryOptions<GetFilesData, GetFilesError, OperationInfiniteData<TData, GetFilesParameters>, GetFilesData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFilesData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetFilesParameters>, GetFilesError | Error>;
+        useSuspenseInfiniteQuery<TPageParam extends GetFilesParameters, TData = GetFilesData>(parameters: ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options: Omit<UseSuspenseInfiniteQueryOptions<GetFilesData, GetFilesError, OperationInfiniteData<TData, GetFilesParameters>, GetFilesData, ServiceOperationInfiniteQueryKey<GetFilesSchema, GetFilesParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFilesData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetFilesParameters>, GetFilesError | Error>;
         /**
          * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
          * Similar to useQueries but integrates with React Suspense for loading states.
@@ -391,7 +391,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useSuspenseQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (GetFilesParameters), options?: Omit<UseSuspenseQueryOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetFilesError | Error>;
+        useSuspenseQuery<TData = GetFilesData>(parameters: ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters> | (DeepReadonly<GetFilesParameters>), options?: Omit<UseSuspenseQueryOptions<GetFilesData, GetFilesError, TData, ServiceOperationQueryKey<GetFilesSchema, GetFilesParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetFilesError | Error>;
         schema: GetFilesSchema;
         types: {
             parameters: GetFilesParameters;
@@ -402,7 +402,7 @@ export interface FilesService {
     /** @summary Upload a files by ID */
     postFiles: {
         /** @summary Upload a files by ID */
-        getMutationKey(parameters: PostFilesParameters | void): ServiceOperationMutationKey<PostFilesSchema, PostFilesParameters>;
+        getMutationKey(parameters: DeepReadonly<PostFilesParameters> | void): ServiceOperationMutationKey<PostFilesSchema, PostFilesParameters>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -421,7 +421,7 @@ export interface FilesService {
          * });
          * ```
          */
-        useMutation<TVariables extends PostFilesBody, TContext = unknown>(parameters: PostFilesParameters, options?: ServiceOperationUseMutationOptions<PostFilesSchema, PostFilesData, PostFilesParameters, TVariables, PostFilesError | Error, TContext>): UseMutationResult<PostFilesData, PostFilesError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
+        useMutation<TVariables extends PostFilesBody, TContext = unknown>(parameters: DeepReadonly<PostFilesParameters>, options?: ServiceOperationUseMutationOptions<PostFilesSchema, PostFilesData, PostFilesParameters, TVariables, PostFilesError | Error, TContext>): UseMutationResult<PostFilesData, PostFilesError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -501,7 +501,7 @@ export interface FilesService {
     /** @summary Delete all files */
     deleteFiles: {
         /** @summary Delete all files */
-        getMutationKey(parameters: DeleteFilesParameters | void): ServiceOperationMutationKey<DeleteFilesSchema, DeleteFilesParameters>;
+        getMutationKey(parameters: DeepReadonly<DeleteFilesParameters> | void): ServiceOperationMutationKey<DeleteFilesSchema, DeleteFilesParameters>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -527,7 +527,7 @@ export interface FilesService {
          * });
          * ```
          */
-        useMutation<TVariables extends DeleteFilesBody, TContext = unknown>(parameters: DeleteFilesParameters, options?: ServiceOperationUseMutationOptions<DeleteFilesSchema, DeleteFilesData, DeleteFilesParameters, TVariables, DeleteFilesError | Error, TContext>): UseMutationResult<DeleteFilesData, DeleteFilesError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
+        useMutation<TVariables extends DeleteFilesBody, TContext = unknown>(parameters: DeepReadonly<DeleteFilesParameters>, options?: ServiceOperationUseMutationOptions<DeleteFilesSchema, DeleteFilesData, DeleteFilesParameters, TVariables, DeleteFilesError | Error, TContext>): UseMutationResult<DeleteFilesData, DeleteFilesError | Error, AreAllOptional<TVariables> extends true ? TVariables | void : TVariables, TContext>;
         /**
          * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
          * Handles loading state, optimistic updates, and error handling.
@@ -633,7 +633,7 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        getQueryKey(parameters: GetFileListParameters | void): ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>;
+        getQueryKey(parameters: DeepReadonly<GetFileListParameters> | void): ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -656,7 +656,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options?: Omit<UndefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseQueryResult<TData, GetFileListError | Error>;
+        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options?: Omit<UndefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseQueryResult<TData, GetFileListError | Error>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -679,7 +679,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options: Omit<DefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFileListError | Error>;
+        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options: Omit<DefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFileListError | Error>;
         /**
          * @deprecated
          * @summary Get a file list
@@ -714,7 +714,7 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void)): OperationInfiniteData<GetFileListData, GetFileListParameters> | undefined;
+        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void)): OperationInfiniteData<GetFileListData, GetFileListParameters> | undefined;
         /**
          * @deprecated
          * @summary Get a file list
@@ -730,17 +730,17 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        getQueryData(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void)): GetFileListData | undefined;
+        getQueryData(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void)): GetFileListData | undefined;
         /**
          * @deprecated
          * @summary Get a file list
          */
-        getQueryState(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void)): QueryState<GetFileListData, GetFileListError> | undefined;
+        getQueryState(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void)): QueryState<GetFileListData, GetFileListError> | undefined;
         /**
          * @deprecated
          * @summary Get a file list
          */
-        getInfiniteQueryState(parameters: GetFileListParameters | ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | void): QueryState<OperationInfiniteData<GetFileListData, GetFileListParameters>, GetFileListError> | undefined;
+        getInfiniteQueryState(parameters: DeepReadonly<GetFileListParameters> | ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | void): QueryState<OperationInfiniteData<GetFileListData, GetFileListParameters>, GetFileListError> | undefined;
         /**
          * @deprecated
          * @summary Get a file list
@@ -779,7 +779,7 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        setInfiniteQueryData(parameters: GetFileListParameters | ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, updater: Updater<NoInfer<OperationInfiniteData<GetFileListData, GetFileListParameters>> | undefined, NoInfer<OperationInfiniteData<GetFileListData, GetFileListParameters>> | undefined>, options?: SetDataOptions): OperationInfiniteData<GetFileListData, GetFileListParameters> | undefined;
+        setInfiniteQueryData(parameters: (DeepReadonly<GetFileListParameters> | undefined) | ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, updater: Updater<NoInfer<OperationInfiniteData<GetFileListData, GetFileListParameters>> | undefined, NoInfer<DeepReadonly<OperationInfiniteData<GetFileListData, GetFileListParameters>>> | undefined>, options?: SetDataOptions): OperationInfiniteData<GetFileListData, GetFileListParameters> | undefined;
         /**
          * @deprecated
          * @summary Get a file list
@@ -789,12 +789,12 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        setQueryData(parameters: (GetFileListParameters | undefined) | ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>, updater: Updater<NoInfer<GetFileListData> | undefined, NoInfer<GetFileListData> | undefined>, options?: SetDataOptions): GetFileListData | undefined;
+        setQueryData(parameters: (DeepReadonly<GetFileListParameters> | undefined) | ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>, updater: Updater<NoInfer<GetFileListData> | undefined, NoInfer<DeepReadonly<GetFileListData>> | undefined>, options?: SetDataOptions): GetFileListData | undefined;
         /**
          * @deprecated
          * @summary Get a file list
          */
-        getInfiniteQueryKey(parameters: GetFileListParameters | void): ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>;
+        getInfiniteQueryKey(parameters: DeepReadonly<GetFileListParameters> | void): ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -820,7 +820,7 @@ export interface FilesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useInfiniteQuery<TPageParam extends GetFileListParameters, TQueryFnData = GetFileListData, TData = OperationInfiniteData<TQueryFnData, GetFileListParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, GetFileListError, TData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<TPageParam>>): UseInfiniteQueryResult<TData, GetFileListError | Error>;
+        useInfiniteQuery<TPageParam extends GetFileListParameters, TQueryFnData = GetFileListData, TData = OperationInfiniteData<TQueryFnData, GetFileListParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, GetFileListError, TData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<TPageParam>>): UseInfiniteQueryResult<TData, GetFileListError | Error>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -846,7 +846,7 @@ export interface FilesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useInfiniteQuery<TPageParam extends GetFileListParameters, TQueryFnData = GetFileListData, TData = OperationInfiniteData<TQueryFnData, GetFileListParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, GetFileListError, TData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFileListData, PartialParameters<TPageParam>>): DefinedUseInfiniteQueryResult<TData, GetFileListError | Error>;
+        useInfiniteQuery<TPageParam extends GetFileListParameters, TQueryFnData = GetFileListData, TData = OperationInfiniteData<TQueryFnData, GetFileListParameters>>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, GetFileListError, TData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFileListData, PartialParameters<TPageParam>>): DefinedUseInfiniteQueryResult<TData, GetFileListError | Error>;
         /**
          * Monitors the number of queries currently fetching, matching the provided filters.
          * Useful for creating loading indicators or performing actions based on active requests.
@@ -937,7 +937,7 @@ export interface FilesService {
          * @deprecated
          * @summary Get a file list
          */
-        getQueryKey(parameters: GetFileListParameters | void): ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>;
+        getQueryKey(parameters: DeepReadonly<GetFileListParameters> | void): ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -960,7 +960,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options?: Omit<UndefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseQueryResult<TData, GetFileListError | Error>;
+        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options?: Omit<UndefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseQueryResult<TData, GetFileListError | Error>;
         /**
          * Performs asynchronous data fetching, manages loading states and error handling.
          *
@@ -983,7 +983,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options: Omit<DefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFileListError | Error>;
+        useQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options: Omit<DefinedInitialDataOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): DefinedUseQueryResult<TData, GetFileListError | Error>;
         /**
          * Performs asynchronous data fetching with support for infinite scrolling scenarios.
          * Manages paginated data and provides utilities for fetching additional pages.
@@ -1010,7 +1010,7 @@ export interface FilesService {
          * fetchNextPage(); // Fetch the next page
          * ```
          */
-        useSuspenseInfiniteQuery<TPageParam extends GetFileListParameters, TData = GetFileListData>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options: Omit<UseSuspenseInfiniteQueryOptions<GetFileListData, GetFileListError, OperationInfiniteData<TData, GetFileListParameters>, GetFileListData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFileListData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetFileListParameters>, GetFileListError | Error>;
+        useSuspenseInfiniteQuery<TPageParam extends GetFileListParameters, TData = GetFileListData>(parameters: ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options: Omit<UseSuspenseInfiniteQueryOptions<GetFileListData, GetFileListError, OperationInfiniteData<TData, GetFileListParameters>, GetFileListData, ServiceOperationInfiniteQueryKey<GetFileListSchema, GetFileListParameters>, PartialParameters<TPageParam>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<GetFileListData, PartialParameters<TPageParam>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, GetFileListParameters>, GetFileListError | Error>;
         /**
          * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
          * Similar to useQueries but integrates with React Suspense for loading states.
@@ -1095,7 +1095,7 @@ export interface FilesService {
          * })
          * ```
          */
-        useSuspenseQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (GetFileListParameters | void), options?: Omit<UseSuspenseQueryOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetFileListError | Error>;
+        useSuspenseQuery<TData = GetFileListData>(parameters: ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters> | (DeepReadonly<GetFileListParameters> | void), options?: Omit<UseSuspenseQueryOptions<GetFileListData, GetFileListError, TData, ServiceOperationQueryKey<GetFileListSchema, GetFileListParameters>>, "queryKey">): UseSuspenseQueryResult<TData, GetFileListError | Error>;
         schema: GetFileListSchema;
         types: {
             parameters: GetFileListParameters;

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationGetInfiniteQueryData.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationGetInfiniteQueryData.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   OperationInfiniteData,
   ServiceOperationInfiniteQueryKey,
 } from '@openapi-qraft/tanstack-query-react-types';
@@ -12,6 +13,8 @@ export interface ServiceOperationGetInfiniteQueryData<
   getInfiniteQueryData(
     parameters:
       | ServiceOperationInfiniteQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams)
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>)
   ): OperationInfiniteData<TOperationQueryFnData, TParams> | undefined;
 }

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationGetQueryData.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationGetQueryData.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   ServiceOperationQueryKey,
 } from '@openapi-qraft/tanstack-query-react-types';
 
@@ -11,6 +12,8 @@ export interface ServiceOperationGetQueryData<
   getQueryData(
     parameters:
       | ServiceOperationQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams)
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>)
   ): TOperationQueryFnData | undefined;
 }

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationGetQueryState.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationGetQueryState.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   OperationInfiniteData,
   ServiceOperationInfiniteQueryKey,
   ServiceOperationQueryKey,
@@ -15,13 +16,20 @@ export interface ServiceOperationGetQueryState<
   getQueryState(
     parameters:
       | ServiceOperationQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams)
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>)
   ): QueryState<TOperationQueryFnData, TError> | undefined;
 
   getInfiniteQueryState(
     parameters: AreAllOptional<TParams> extends true
-      ? TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams> | void
-      : TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>
+      ?
+          | DeepReadonly<TParams>
+          | ServiceOperationInfiniteQueryKey<TSchema, TParams>
+          | void
+      :
+          | DeepReadonly<TParams>
+          | ServiceOperationInfiniteQueryKey<TSchema, TParams>
   ):
     | QueryState<OperationInfiniteData<TOperationQueryFnData, TParams>, TError>
     | undefined;

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationSetInfiniteQueryData.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationSetInfiniteQueryData.ts
@@ -1,4 +1,6 @@
 import type {
+  AreAllOptional,
+  DeepReadonly,
   OperationInfiniteData,
   ServiceOperationInfiniteQueryKey,
 } from '@openapi-qraft/tanstack-query-react-types';
@@ -7,14 +9,21 @@ import type { NoInfer, SetDataOptions, Updater } from '@tanstack/query-core';
 export interface ServiceOperationSetInfiniteQueryData<
   TSchema extends { url: string; method: string },
   TOperationQueryFnData,
-  TParams = {},
+  TParams,
 > {
   setInfiniteQueryData(
-    parameters: TParams | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
+    parameters:
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | undefined
+          : DeepReadonly<TParams>)
+      | ServiceOperationInfiniteQueryKey<TSchema, TParams>,
     updater: Updater<
       | NoInfer<OperationInfiniteData<TOperationQueryFnData, TParams>>
       | undefined,
-      NoInfer<OperationInfiniteData<TOperationQueryFnData, TParams>> | undefined
+      | NoInfer<
+          DeepReadonly<OperationInfiniteData<TOperationQueryFnData, TParams>>
+        >
+      | undefined
     >,
     options?: SetDataOptions
   ): OperationInfiniteData<TOperationQueryFnData, TParams> | undefined;

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationSetQueryData.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationSetQueryData.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   ServiceOperationQueryKey,
 } from '@openapi-qraft/tanstack-query-react-types';
 import type { NoInfer, SetDataOptions, Updater } from '@tanstack/query-core';
@@ -11,11 +12,13 @@ export interface ServiceOperationSetQueryData<
 > {
   setQueryData(
     parameters:
-      | (AreAllOptional<TParams> extends true ? TParams | undefined : TParams)
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | undefined
+          : DeepReadonly<TParams>)
       | ServiceOperationQueryKey<TSchema, TParams>,
     updater: Updater<
       NoInfer<TOperationQueryFnData> | undefined,
-      NoInfer<TOperationQueryFnData> | undefined
+      NoInfer<DeepReadonly<TOperationQueryFnData>> | undefined
     >,
     options?: SetDataOptions
   ): TOperationQueryFnData | undefined;

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseInfiniteQuery.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseInfiniteQuery.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   OperationInfiniteData,
   PartialParameters,
   ServiceOperationInfiniteQueryKey,
@@ -19,7 +20,9 @@ export interface ServiceOperationUseInfiniteQuery<
   TError,
 > {
   getInfiniteQueryKey(
-    parameters: AreAllOptional<TParams> extends true ? TParams | void : TParams
+    parameters: AreAllOptional<TParams> extends true
+      ? DeepReadonly<TParams> | void
+      : DeepReadonly<TParams>
   ): ServiceOperationInfiniteQueryKey<TSchema, TParams>;
 
   useInfiniteQuery<
@@ -29,7 +32,9 @@ export interface ServiceOperationUseInfiniteQuery<
   >(
     parameters:
       | ServiceOperationInfiniteQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>),
     options: Omit<
       UndefinedInitialDataInfiniteOptions<
         TQueryFnData,
@@ -56,7 +61,9 @@ export interface ServiceOperationUseInfiniteQuery<
   >(
     parameters:
       | ServiceOperationInfiniteQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>),
     options: Omit<
       DefinedInitialDataInfiniteOptions<
         TQueryFnData,

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseMutation.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseMutation.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   MutationVariables,
   ServiceOperationMutationKey,
   ServiceOperationUseMutationOptions,
@@ -14,11 +15,11 @@ export interface ServiceOperationUseMutation<
   TError,
 > {
   getMutationKey(
-    parameters: TParams | void
+    parameters: DeepReadonly<TParams> | void
   ): ServiceOperationMutationKey<TSchema, TParams>;
 
   useMutation<TVariables extends TBody, TContext = unknown>(
-    parameters: TParams,
+    parameters: DeepReadonly<TParams>,
     options?: ServiceOperationUseMutationOptions<
       TSchema,
       TMutationData,

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseQuery.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseQuery.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   ServiceOperationQueryKey,
 } from '@openapi-qraft/tanstack-query-react-types';
 import type {
@@ -16,13 +17,17 @@ export interface ServiceOperationUseQuery<
   TError,
 > {
   getQueryKey(
-    parameters: AreAllOptional<TParams> extends true ? TParams | void : TParams
+    parameters: AreAllOptional<TParams> extends true
+      ? DeepReadonly<TParams> | void
+      : DeepReadonly<TParams>
   ): ServiceOperationQueryKey<TSchema, TParams>;
 
   useQuery<TData = TOperationQueryFnData>(
     parameters:
       | ServiceOperationQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>),
     options?: Omit<
       UndefinedInitialDataOptions<
         TOperationQueryFnData,
@@ -37,7 +42,9 @@ export interface ServiceOperationUseQuery<
   useQuery<TData = TOperationQueryFnData>(
     parameters:
       | ServiceOperationQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>),
     options: Omit<
       DefinedInitialDataOptions<
         TOperationQueryFnData,

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseSuspenseInfiniteQuery.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseSuspenseInfiniteQuery.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   OperationInfiniteData,
   PartialParameters,
   ServiceOperationInfiniteQueryKey,
@@ -22,7 +23,9 @@ export interface ServiceOperationUseSuspenseInfiniteQuery<
   >(
     parameters:
       | ServiceOperationInfiniteQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>),
     options: Omit<
       UseSuspenseInfiniteQueryOptions<
         TOperationQueryFnData,

--- a/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseSuspenseQuery.ts
+++ b/packages/tanstack-query-react-types/src/service-operation/ServiceOperationUseSuspenseQuery.ts
@@ -1,5 +1,6 @@
 import type {
   AreAllOptional,
+  DeepReadonly,
   ServiceOperationQueryKey,
 } from '@openapi-qraft/tanstack-query-react-types';
 import type {
@@ -16,7 +17,9 @@ export interface ServiceOperationUseSuspenseQuery<
   useSuspenseQuery<TData = TOperationQueryFnData>(
     parameters:
       | ServiceOperationQueryKey<TSchema, TParams>
-      | (AreAllOptional<TParams> extends true ? TParams | void : TParams),
+      | (AreAllOptional<TParams> extends true
+          ? DeepReadonly<TParams> | void
+          : DeepReadonly<TParams>),
     options?: Omit<
       UseSuspenseQueryOptions<
         TOperationQueryFnData,

--- a/packages/tanstack-query-react-types/src/shared/DeepReadonly.ts
+++ b/packages/tanstack-query-react-types/src/shared/DeepReadonly.ts
@@ -1,0 +1,7 @@
+export type DeepReadonly<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends Array<infer U>
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [P in keyof T]: DeepReadonly<T[P]> }
+      : T;

--- a/packages/tanstack-query-react-types/src/shared/MutationFilters.ts
+++ b/packages/tanstack-query-react-types/src/shared/MutationFilters.ts
@@ -5,6 +5,7 @@ import type {
 } from '@tanstack/query-core';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AreAllOptional } from './AreAllOptional.js';
+import type { DeepReadonly } from './DeepReadonly.js';
 import type { PartialParameters } from './PartialParameters.js';
 import type { ServiceOperationMutationKey } from './ServiceOperationKey.js';
 
@@ -47,7 +48,7 @@ export interface MutationFiltersByParameters<
   /**
    * Include mutations matching these parameters
    */
-  parameters?: PartialParameters<TParams>;
+  parameters?: PartialParameters<DeepReadonly<TParams>>;
   mutationKey?: never;
 }
 

--- a/packages/tanstack-query-react-types/src/shared/QueryFilters.ts
+++ b/packages/tanstack-query-react-types/src/shared/QueryFilters.ts
@@ -1,4 +1,5 @@
 import type { DefaultError, FetchStatus, Query } from '@tanstack/query-core';
+import type { DeepReadonly } from './DeepReadonly.js';
 import type { OperationInfiniteData } from './OperationInfiniteData.js';
 import type { PartialParameters } from './PartialParameters.js';
 import type {
@@ -150,7 +151,7 @@ interface QueryFiltersByExactParameters<
   /**
    * Include queries matching parameters
    */
-  parameters: TParams;
+  parameters: DeepReadonly<TParams>;
 }
 
 interface QueryFiltersByWeakParameters<
@@ -174,7 +175,7 @@ interface QueryFiltersByWeakParameters<
   /**
    * Include queries matching parameters
    */
-  parameters?: PartialParameters<TParams>;
+  parameters?: PartialParameters<DeepReadonly<TParams>>;
 }
 
 export type QueryFiltersByParameters<

--- a/packages/tanstack-query-react-types/src/shared/ServiceOperationFetchInfiniteQueryOptions.ts
+++ b/packages/tanstack-query-react-types/src/shared/ServiceOperationFetchInfiniteQueryOptions.ts
@@ -6,6 +6,7 @@ import type {
   QueryFunction,
 } from '@tanstack/query-core';
 import type { AreAllOptional } from './AreAllOptional.js';
+import type { DeepReadonly } from './DeepReadonly.js';
 import type { OperationInfiniteData } from './OperationInfiniteData.js';
 import type { PartialParameters } from './PartialParameters.js';
 import type { RequestFn } from './RequestFn.js';
@@ -138,7 +139,7 @@ type FetchInfiniteQueryOptionsByParameters<
   /**
    * Fetch Queries by parameters
    */
-  parameters?: TParams;
+  parameters?: DeepReadonly<TParams>;
   queryKey?: never;
 };
 

--- a/packages/tanstack-query-react-types/src/shared/ServiceOperationFetchQueryOptions.ts
+++ b/packages/tanstack-query-react-types/src/shared/ServiceOperationFetchQueryOptions.ts
@@ -4,6 +4,7 @@ import type {
   FetchQueryOptions,
   QueryFunction,
 } from '@tanstack/query-core';
+import type { DeepReadonly } from './DeepReadonly.js';
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
 export type ServiceOperationFetchQueryOptions<
@@ -69,7 +70,7 @@ interface FetchQueryOptionsByParameters<
   /**
    * Fetch Queries by parameters
    */
-  parameters: TParams;
+  parameters: DeepReadonly<TParams>;
   queryKey?: never;
 }
 

--- a/packages/tanstack-query-react-types/src/shared/ServiceOperationMutation.ts
+++ b/packages/tanstack-query-react-types/src/shared/ServiceOperationMutation.ts
@@ -1,4 +1,5 @@
 import type { AreAllOptional } from '@openapi-qraft/tanstack-query-react-types';
+import type { DeepReadonly } from './DeepReadonly.js';
 
 interface QueryFnBaseUrlOptions {
   /**
@@ -14,19 +15,19 @@ export type ServiceOperationMutationFnOptions<TBody, TParams> =
       ?
           | void // todo::try to move void to arguments
           | ({
-              parameters?: TParams;
+              parameters?: DeepReadonly<TParams>;
               body?: TBody;
             } & QueryFnBaseUrlOptions)
       : {
-          parameters: TParams;
+          parameters: DeepReadonly<TParams>;
           body?: TBody;
         } & QueryFnBaseUrlOptions
     : AreAllOptional<TParams> extends true
       ? {
-          parameters?: TParams;
+          parameters?: DeepReadonly<TParams>;
           body: TBody;
         } & QueryFnBaseUrlOptions
       : {
-          parameters: TParams;
+          parameters: DeepReadonly<TParams>;
           body: TBody;
         } & QueryFnBaseUrlOptions;

--- a/packages/tanstack-query-react-types/src/shared/ServiceOperationQuery.ts
+++ b/packages/tanstack-query-react-types/src/shared/ServiceOperationQuery.ts
@@ -1,4 +1,5 @@
 import type { ServiceOperationQueryKey } from '@openapi-qraft/tanstack-query-react-types';
+import type { DeepReadonly } from './DeepReadonly.js';
 
 interface QueryFnOptionsBase<
   TMeta extends Record<string, any>,
@@ -14,7 +15,7 @@ export interface QueryFnOptionsByParameters<
   TSignal extends AbortSignal = AbortSignal,
 > extends QueryFnOptionsBase<TMeta, TSignal>,
     QueryFnBaseUrlOptions {
-  parameters: TParams;
+  parameters: DeepReadonly<TParams>;
 
   queryKey?: never;
 }

--- a/packages/tanstack-query-react-types/src/shared/UseQueryOptionsForUseQueries.ts
+++ b/packages/tanstack-query-react-types/src/shared/UseQueryOptionsForUseQueries.ts
@@ -1,5 +1,6 @@
 import type { QueriesPlaceholderDataFunction } from '@tanstack/query-core';
 import type { UseQueryOptions } from '@tanstack/react-query';
+import type { DeepReadonly } from './DeepReadonly.js';
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
 export type UseQueryOptionsForUseQueries<
@@ -19,7 +20,7 @@ export type UseQueryOptionsForUseQueries<
 > &
   (
     | {
-        parameters: TParams;
+        parameters: DeepReadonly<TParams>;
         placeholderData?:
           | TQueryFnData
           | QueriesPlaceholderDataFunction<TQueryFnData>;

--- a/packages/tanstack-query-react-types/src/shared/UseQueryOptionsForUseSuspenseQuery.ts
+++ b/packages/tanstack-query-react-types/src/shared/UseQueryOptionsForUseSuspenseQuery.ts
@@ -1,4 +1,5 @@
 import type { UseQueryOptions } from '@tanstack/react-query';
+import type { DeepReadonly } from './DeepReadonly.js';
 import type { ServiceOperationQueryKey } from './ServiceOperationKey.js';
 
 export type UseQueryOptionsForUseSuspenseQuery<
@@ -18,7 +19,7 @@ export type UseQueryOptionsForUseSuspenseQuery<
 > &
   (
     | {
-        parameters: TParams;
+        parameters: DeepReadonly<TParams>;
         queryKey?: never;
       }
     | {

--- a/packages/tanstack-query-react-types/src/shared/index.ts
+++ b/packages/tanstack-query-react-types/src/shared/index.ts
@@ -1,4 +1,5 @@
 export type * from './AreAllOptional.js';
+export type * from './DeepReadonly.js';
 export type * from './InvalidateQueryFilters.js';
 export type * from './MutationFilters.js';
 export type * from './OperationInfiniteData.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6099,6 +6099,7 @@ __metadata:
   dependencies:
     "@openapi-qraft/eslint-config": "workspace:*"
     "@openapi-qraft/plugin": "workspace:^"
+    "@openapi-qraft/tanstack-query-react-types": "workspace:*"
     "@openapi-qraft/test-fixtures": "workspace:*"
     "@openapi-qraft/ts-factory-code-generator": "workspace:*"
     camelcase: "npm:^8.0.0"


### PR DESCRIPTION
Previously, calling methods like `setQueryData()` with `as const` objects would result in a type error:

```ts
const parameters = {
  query: { id__in: ['1', '2'] },
  header: { 'x-version': '2' },
} as const;

const data = { query: { id__in: ['1'] } } as const;

qraft.files.getFiles.setQueryData(parameters, data); // ❌ Type error
```

This PR improves developer experience by allowing read-only (immutable) query, body, and headers objects to be passed into such methods without the need for explicit type casting.