### PR TITLE
fix: add proper error handling for `<QraftSecureRequestFn/>`

### DIFF
--- a/.changeset/great-chefs-lie.md
+++ b/.changeset/great-chefs-lie.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': patch
+---
+
+Fixed error handling issues with `<QraftSecureRequestFn/>` by implementing dedicated error rejection handling instead of incorrectly using the same resolver for both success and error cases.

--- a/packages/react-client/src/callbacks/useMutation.ts
+++ b/packages/react-client/src/callbacks/useMutation.ts
@@ -10,6 +10,7 @@ import type { UseMutationResult } from '@tanstack/react-query';
 import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import { useMutation as useMutationBase } from '@tanstack/react-query';
 import { composeMutationKey } from '../lib/composeMutationKey.js';
+import { requestFnResponseRejecter } from '../lib/requestFnResponseRejecter.js';
 import { requestFnResponseResolver } from '../lib/requestFnResponseResolver.js';
 
 export const useMutation: <
@@ -69,7 +70,7 @@ export const useMutation: <
                   baseUrl: qraftOptions.baseUrl,
                   body: bodyPayload as never,
                 })
-                .then(requestFnResponseResolver, requestFnResponseResolver);
+                .then(requestFnResponseResolver, requestFnResponseRejecter);
             }
           : function (parametersAndBodyPayload) {
               const { body, ...parameters } = parametersAndBodyPayload as {
@@ -82,7 +83,7 @@ export const useMutation: <
                   baseUrl: qraftOptions.baseUrl,
                   body,
                 } as never)
-                .then(requestFnResponseResolver, requestFnResponseResolver);
+                .then(requestFnResponseResolver, requestFnResponseRejecter);
             }),
     },
     qraftOptions.queryClient

--- a/packages/react-client/src/callbacks/useQueries.ts
+++ b/packages/react-client/src/callbacks/useQueries.ts
@@ -9,6 +9,7 @@ import type { QueriesResults } from '@tanstack/react-query';
 import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import { useQueries as useQueriesTanstack } from '@tanstack/react-query';
 import { composeQueryKey } from '../lib/composeQueryKey.js';
+import { requestFnResponseRejecter } from '../lib/requestFnResponseRejecter.js';
 import { requestFnResponseResolver } from '../lib/requestFnResponseResolver.js';
 
 export const useQueries: (
@@ -56,7 +57,7 @@ export const useQueries: (
                   signal,
                   meta,
                 })
-                .then(requestFnResponseResolver, requestFnResponseResolver);
+                .then(requestFnResponseResolver, requestFnResponseRejecter);
             },
         };
       }),

--- a/packages/react-client/src/callbacks/useSuspenseQueries.ts
+++ b/packages/react-client/src/callbacks/useSuspenseQueries.ts
@@ -9,6 +9,7 @@ import type { SuspenseQueriesResults } from '@tanstack/react-query';
 import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import { useSuspenseQueries as useSuspenseQueriesTanstack } from '@tanstack/react-query';
 import { composeQueryKey } from '../lib/composeQueryKey.js';
+import { requestFnResponseRejecter } from '../lib/requestFnResponseRejecter.js';
 import { requestFnResponseResolver } from '../lib/requestFnResponseResolver.js';
 
 export const useSuspenseQueries: (
@@ -56,7 +57,7 @@ export const useSuspenseQueries: (
                   signal,
                   meta,
                 })
-                .then(requestFnResponseResolver, requestFnResponseResolver);
+                .then(requestFnResponseResolver, requestFnResponseRejecter);
             },
         };
       }),

--- a/packages/react-client/src/lib/callQueryClientFetchMethod.ts
+++ b/packages/react-client/src/lib/callQueryClientFetchMethod.ts
@@ -3,6 +3,7 @@ import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema, RequestFn } from './requestFn.js';
 import { composeInfiniteQueryKey } from './composeInfiniteQueryKey.js';
 import { composeQueryKey } from './composeQueryKey.js';
+import { requestFnResponseRejecter } from './requestFnResponseRejecter.js';
 import { requestFnResponseResolver } from './requestFnResponseResolver.js';
 import { shelfMerge } from './shelfMerge.js';
 
@@ -56,7 +57,7 @@ export function callQueryClientMethodWithQueryKey<
             baseUrl,
             signal,
             meta,
-          }).then(requestFnResponseResolver, requestFnResponseResolver);
+          }).then(requestFnResponseResolver, requestFnResponseRejecter);
         }
       : undefined);
 

--- a/packages/react-client/src/lib/requestFn.test.ts
+++ b/packages/react-client/src/lib/requestFn.test.ts
@@ -1,0 +1,125 @@
+import type { OperationSchema } from '@openapi-qraft/tanstack-query-react-types';
+import { describe, expect, it } from 'vitest';
+import { bodySerializer } from './requestFn.js';
+
+describe('requestFn', () => {
+  describe('bodySerializer', () => {
+    const createSchema = (
+      method: OperationSchema['method'],
+      mediaType?: string[]
+    ): OperationSchema => ({
+      method,
+      url: '/test',
+      mediaType,
+    });
+
+    it('should return undefined for GET, HEAD, and OPTIONS methods', () => {
+      const methods = ['get', 'head', 'options'] as const;
+      methods.forEach((method) => {
+        const schema = createSchema(method);
+        expect(bodySerializer(schema, { data: 'test' })).toBeUndefined();
+      });
+    });
+
+    it('should return undefined for null or undefined body', () => {
+      const schema = createSchema('post');
+      expect(bodySerializer(schema, null)).toBeUndefined();
+      expect(bodySerializer(schema, undefined)).toBeUndefined();
+    });
+
+    it('should handle string body', () => {
+      const schema = createSchema('post', ['text/plain']);
+      const result = bodySerializer(schema, 'test string');
+      expect(result).toEqual({
+        body: 'test string',
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      });
+    });
+
+    it('should handle FormData body', () => {
+      const schema = createSchema('post');
+      const formData = new FormData();
+      formData.append('test', 'value');
+
+      const result = bodySerializer(schema, formData);
+      expect(result).toEqual({
+        body: formData,
+        headers: {
+          // If the serialized body is FormData, remove the 'Content-Type' header.
+          // The browser will automatically set the correct `Content-Type` and boundary expression.
+          'Content-Type': null,
+        },
+      });
+    });
+
+    it('should handle Blob body', () => {
+      const schema = createSchema('post', ['application/octet-stream']);
+      const blob = new Blob(['test'], { type: 'text/plain' });
+
+      const result = bodySerializer(schema, blob);
+      expect(result).toEqual({
+        body: blob,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      });
+    });
+
+    it('should handle JSON body with form-data media type', () => {
+      const schema = createSchema('post', ['multipart/form-data']);
+      const body = { test: 'value', file: new Blob(['test']) };
+
+      const result = bodySerializer(schema, body)!;
+      expect(result).toEqual({
+        body: expect.any(FormData),
+        headers: {
+          'Content-Type': null,
+        },
+      });
+
+      const formData = result.body as FormData;
+      expect(formData.get('test')).toBe('value');
+      expect(formData.get('file')).toBeInstanceOf(Blob);
+    });
+
+    it('should handle JSON body with JSON media type', () => {
+      const schema = createSchema('post', ['application/json']);
+      const body = { test: 'value' };
+
+      const result = bodySerializer(schema, body);
+      expect(result).toEqual({
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    it('should handle complex nested objects in form-data', () => {
+      const schema = createSchema('post', ['multipart/form-data']);
+      const body = {
+        simple: 'value',
+        array: [1, 2, 3],
+        nested: { key: 'value' },
+        file: new Blob(['test']),
+      };
+
+      const result = bodySerializer(schema, body)!;
+      expect(result).toEqual({
+        body: expect.any(FormData),
+        headers: {
+          'Content-Type': null,
+        },
+      });
+
+      const formData = result.body as FormData;
+
+      expect(formData.get('simple')).toBe('value');
+      expect(formData.getAll('array')).toEqual(['1', '2', '3']);
+      expect(formData.get('nested')).toBe(JSON.stringify({ key: 'value' }));
+      expect(formData.get('file')).toBeInstanceOf(Blob);
+    });
+  });
+});

--- a/packages/react-client/src/lib/requestFnResponseRejecter.test.ts
+++ b/packages/react-client/src/lib/requestFnResponseRejecter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { requestFnResponseRejecter } from './requestFnResponseRejecter.js';
+
+describe('requestFnResponseRejecter', () => {
+  it('should throw error if input is an Error instance', () => {
+    const error = new Error('Test error');
+    expect(() => requestFnResponseRejecter(error)).toThrow(error);
+  });
+
+  it('should throw error from error property if input contains error field', () => {
+    const customError = new Error('Error from error property');
+    const responseWithError = { error: customError };
+    expect(() => requestFnResponseRejecter(responseWithError)).toThrow(
+      customError
+    );
+  });
+
+  it('should throw generic "Unhandled `requestFn` response" if input does not match known formats', () => {
+    const unknownResponse = { data: 'some data' };
+    expect(() =>
+      requestFnResponseRejecter(
+        // @ts-expect-error - invalid test case
+        unknownResponse
+      )
+    ).toThrow('Unhandled `requestFn` response');
+  });
+
+  it('should add source data to cause property when throwing unhandled response error', () => {
+    const unknownResponse = { data: 'some data' };
+
+    try {
+      requestFnResponseRejecter(
+        // @ts-expect-error - invalid test case
+        unknownResponse
+      );
+      expect.fail('Expected an error to be thrown');
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toBe('Unhandled `requestFn` response');
+        expect(error.cause).toBe(unknownResponse);
+      } else {
+        expect.fail('Thrown error should be an instance of Error');
+      }
+    }
+  });
+});

--- a/packages/react-client/src/lib/requestFnResponseRejecter.ts
+++ b/packages/react-client/src/lib/requestFnResponseRejecter.ts
@@ -1,0 +1,11 @@
+import type { RequestFnResponse } from './requestFn.js';
+
+export function requestFnResponseRejecter<TData, TError>(
+  requestFnResponseOrError: RequestFnResponse<TData, TError> | Error
+): TData | undefined {
+  if (requestFnResponseOrError instanceof Error) throw requestFnResponseOrError;
+  if ('error' in requestFnResponseOrError) throw requestFnResponseOrError.error;
+  throw new Error('Unhandled `requestFn` response', {
+    cause: requestFnResponseOrError,
+  });
+}

--- a/packages/react-client/src/lib/useComposeUseQueryOptions.ts
+++ b/packages/react-client/src/lib/useComposeUseQueryOptions.ts
@@ -7,6 +7,7 @@ import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema } from './requestFn.js';
 import { composeInfiniteQueryKey } from './composeInfiniteQueryKey.js';
 import { composeQueryKey } from './composeQueryKey.js';
+import { requestFnResponseRejecter } from './requestFnResponseRejecter.js';
 import { requestFnResponseResolver } from './requestFnResponseResolver.js';
 import { shelfMerge } from './shelfMerge.js';
 
@@ -35,7 +36,7 @@ export function useComposeUseQueryOptions(
           signal,
           meta,
         })
-        .then(requestFnResponseResolver, requestFnResponseResolver);
+        .then(requestFnResponseResolver, requestFnResponseRejecter);
     };
 
   const queryKey = Array.isArray(parameters)

--- a/packages/react-client/src/tests/QraftSecureRequestFn.test.tsx
+++ b/packages/react-client/src/tests/QraftSecureRequestFn.test.tsx
@@ -270,6 +270,293 @@ describe('QraftSecureRequestFn', { timeout: 10_000 }, () => {
     ]);
   });
 
+  it('should support Basic Authentication with credentials', async () => {
+    const credentials = 'base_64_credentials=='; // base64 encoded user:password
+
+    const fetchBasicAuth = vi.fn().mockImplementation(() => ({
+      credentials,
+      refreshInterval: 3600000,
+    }));
+
+    const { result } = renderHook(
+      () => useQraft().entities.postEntitiesIdDocuments.useMutation(),
+      {
+        wrapper: (props) => (
+          <QraftSecureRequestFn
+            requestFn={requestFn}
+            securitySchemes={{
+              partnerToken: fetchBasicAuth,
+            }}
+          >
+            {(secureRequestFn) => (
+              <Providers {...props} requestFn={secureRequestFn} />
+            )}
+          </QraftSecureRequestFn>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync(mutationParams);
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.data).toEqual({
+      ...mutationParams,
+      header: {
+        ...mutationParams.header,
+        authorization: `Basic ${credentials}`,
+      },
+    });
+
+    expect(fetchBasicAuth.mock.calls).toEqual([
+      [
+        {
+          isRefreshing: false,
+          signal: new AbortController().signal,
+        },
+      ],
+    ]);
+  });
+
+  it('should support API key in header', async () => {
+    const apiKeyHeader = {
+      in: 'header',
+      name: 'x-api-key',
+      value: 'api-key-value',
+      refreshInterval: 3600000,
+    };
+
+    const fetchApiKey = vi.fn().mockImplementation(() => apiKeyHeader);
+
+    const { result } = renderHook(
+      () => useQraft().entities.postEntitiesIdDocuments.useMutation(),
+      {
+        wrapper: (props) => (
+          <QraftSecureRequestFn
+            requestFn={requestFn}
+            securitySchemes={{
+              partnerToken: fetchApiKey,
+            }}
+          >
+            {(secureRequestFn) => (
+              <Providers {...props} requestFn={secureRequestFn} />
+            )}
+          </QraftSecureRequestFn>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync(mutationParams);
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.data).toEqual({
+      ...mutationParams,
+      header: {
+        ...mutationParams.header,
+        [apiKeyHeader.name]: apiKeyHeader.value,
+      },
+    });
+  });
+
+  it('should support API key in query', async () => {
+    const apiKeyQuery = {
+      in: 'query',
+      name: 'api_key',
+      value: 'api-key-value',
+      refreshInterval: 3600000,
+    };
+
+    const fetchApiKey = vi.fn().mockImplementation(() => apiKeyQuery);
+
+    const { result } = renderHook(
+      () => useQraft().entities.postEntitiesIdDocuments.useMutation(),
+      {
+        wrapper: (props) => (
+          <QraftSecureRequestFn
+            requestFn={requestFn}
+            securitySchemes={{
+              partnerToken: fetchApiKey,
+            }}
+          >
+            {(secureRequestFn) => (
+              <Providers {...props} requestFn={secureRequestFn} />
+            )}
+          </QraftSecureRequestFn>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync(mutationParams);
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.data).toEqual({
+      ...mutationParams,
+      query: {
+        ...mutationParams.query,
+        [apiKeyQuery.name]: apiKeyQuery.value,
+      },
+    });
+  });
+
+  it('should throw error for cookie scheme', async () => {
+    const cookieScheme = {
+      in: 'cookie',
+      refreshInterval: 3600000,
+    };
+
+    const fetchCookieScheme = vi.fn().mockImplementation(() => cookieScheme);
+
+    const { result } = renderHook(
+      () => useQraft().entities.postEntitiesIdDocuments.useMutation(),
+      {
+        wrapper: (props) => (
+          <QraftSecureRequestFn
+            requestFn={requestFn}
+            securitySchemes={{
+              partnerToken: fetchCookieScheme,
+            }}
+          >
+            {(secureRequestFn) => (
+              <Providers {...props} requestFn={secureRequestFn} />
+            )}
+          </QraftSecureRequestFn>
+        ),
+      }
+    );
+
+    await expect(result.current.mutateAsync(mutationParams)).rejects.toThrow(
+      new Error(
+        'Security scheme must be a string, an object with a token property, an object with a credentials property, or an object with an in property that is not equal to "cookie".'
+      )
+    );
+  });
+
+  it('should use refreshInterval from security result object', async () => {
+    const token = 'custom-token';
+    const refreshInterval = 1800000; // 30 minutes
+    let tokenRefreshCounter = 0;
+
+    const fetchCustomToken = vi.fn().mockImplementation(() => ({
+      token: `${token}-${++tokenRefreshCounter}`,
+      refreshInterval,
+    }));
+
+    const queryClient = new QueryClient();
+
+    const { result } = renderHook(
+      () => useQraft().entities.postEntitiesIdDocuments.useMutation(),
+      {
+        wrapper: (props) => (
+          <QraftSecureRequestFn
+            requestFn={requestFn}
+            queryClient={queryClient}
+            securitySchemes={{
+              partnerToken: fetchCustomToken,
+            }}
+          >
+            {(secureRequestFn) => (
+              <Providers {...props} requestFn={secureRequestFn} />
+            )}
+          </QraftSecureRequestFn>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync(mutationParams);
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    // Check that the request was made with token
+    expect(result.current.data).toEqual({
+      ...mutationParams,
+      header: {
+        ...mutationParams.header,
+        authorization: `Bearer ${token}-1`,
+      },
+    });
+
+    // Reset call counter to check subsequent calls
+    fetchCustomToken.mockClear();
+
+    // First mutation after initial request (token should be in cache)
+    await act(async () => {
+      await result.current.mutateAsync({
+        ...mutationParams,
+        header: {
+          'x-monite-version': '2.0.0',
+        },
+      });
+    });
+
+    // Token should not have been refreshed after second request
+    expect(fetchCustomToken).not.toHaveBeenCalled();
+
+    // Advance timer to 85% of interval - token should refresh on next request (80% threshold)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(refreshInterval * 0.85);
+    });
+
+    // Execute third mutation
+    await act(async () => {
+      await result.current.mutateAsync({
+        ...mutationParams,
+        header: {
+          'x-monite-version': '3.0.0',
+        },
+      });
+    });
+
+    // Check that request contains token and refresh function was called
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        ...mutationParams,
+        header: {
+          'x-monite-version': '3.0.0',
+          authorization: `Bearer ${token}-2`,
+        },
+      });
+      expect(fetchCustomToken).toHaveBeenCalledTimes(1);
+      expect(fetchCustomToken).toHaveBeenCalledWith({
+        isRefreshing: true,
+        signal: new AbortController().signal,
+      });
+    });
+
+    // Reset counter and check one more mutation after full interval
+    fetchCustomToken.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(refreshInterval);
+      await result.current.mutateAsync({
+        ...mutationParams,
+        header: {
+          'x-monite-version': '4.0.0',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        ...mutationParams,
+        header: {
+          'x-monite-version': '4.0.0',
+          authorization: `Bearer ${token}-3`,
+        },
+      });
+      expect(fetchCustomToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('refreshes token if expired soon', async () => {
     const token = createTestJwt({ iat: 1593268893, exp: 1593268893 + 3600 });
 

--- a/packages/react-client/src/tests/QraftSecureRequestFn.test.tsx
+++ b/packages/react-client/src/tests/QraftSecureRequestFn.test.tsx
@@ -185,9 +185,6 @@ describe('QraftSecureRequestFn', { timeout: 10_000 }, () => {
             queryClient={queryClient}
             securitySchemes={{
               partnerToken: fetchPartnerToken,
-              foo({ isRefreshing }) {
-                return isRefreshing ? '🔄 refreshing' : '⤴️ initial';
-              },
             }}
           >
             {(secureRequestFn) => (

--- a/packages/react-client/tsconfig.json
+++ b/packages/react-client/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["ES2019", "DOM", "DOM.Iterable"],
+    "lib": ["ES2019", "DOM", "DOM.Iterable", "ES2022.Error"],
     "jsx": "react",
     "verbatimModuleSyntax": true,
     "paths": {

--- a/packages/react-client/vitest.config.ts
+++ b/packages/react-client/vitest.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
       },
     ],
     coverage: {
+      include: ['src/**/*'],
       exclude: [
         'src/service-operation', // only types
         'src/**/*.type.ts', // only types


### PR DESCRIPTION
This PR fixes error handling issues with `<QraftSecureRequestFn/>` by implementing a dedicated `requestFnResponseRejecter` function to properly handle network errors rather than using the same resolver for both success and error paths.