### PR TITLE
fix(204): generate types for empty responses

### DIFF
--- a/.changeset/strong-mugs-fry.md
+++ b/.changeset/strong-mugs-fry.md
@@ -1,0 +1,11 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/test-fixtures': patch
+'@openapi-qraft/plugin': patch
+---
+
+Generate types for empty responses
+
+Now, for both successful and error responses, we generate types for all possible response outcomes.
+For instance, if a 204 (No Content) response is possible, we now explicitly generate a type for it
+(represented as `undefined` in the generated code) instead of omitting it.

--- a/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
@@ -572,7 +572,15 @@ export interface operations {
                             all?: boolean;
                         };
                     };
+                    "application/octet-stream": unknown;
                 };
+            };
+            /** @description No Content - Operation completed successfully, no data returned */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Internal Server Error */
             default: {

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-enum-exports.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-enum-exports.ts.snapshot.ts
@@ -235,7 +235,15 @@ export interface operations {
                             all?: boolean;
                         };
                     };
+                    "application/octet-stream": unknown;
                 };
+            };
+            /** @description No Content - Operation completed successfully, no data returned */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Internal Server Error */
             default: {

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-exports.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-exports.ts.snapshot.ts
@@ -235,7 +235,15 @@ export interface operations {
                             all?: boolean;
                         };
                     };
+                    "application/octet-stream": unknown;
                 };
+            };
+            /** @description No Content - Operation completed successfully, no data returned */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Internal Server Error */
             default: {

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
@@ -255,7 +255,15 @@ export interface operations {
                             all?: boolean;
                         };
                     };
+                    "application/octet-stream": unknown;
                 };
+            };
+            /** @description No Content - Operation completed successfully, no data returned */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Internal Server Error */
             default: {

--- a/packages/plugin/src/lib/open-api/OpenAPISchemaType.ts
+++ b/packages/plugin/src/lib/open-api/OpenAPISchemaType.ts
@@ -25,10 +25,12 @@ export type OpenAPISchemaType = {
         responses: {
           [statusCode in number | 'default']: {
             description: string;
-            content: {
-              [contentType: string]: {
-                schema: any;
-              };
+            content?: {
+              [contentType: string]:
+                | {
+                    schema: any;
+                  }
+                | { type: string };
             };
           };
         };

--- a/packages/plugin/src/lib/open-api/OpenAPIService.ts
+++ b/packages/plugin/src/lib/open-api/OpenAPIService.ts
@@ -23,9 +23,19 @@ export type ServiceOperation = {
   description: string | undefined;
   summary: string | undefined;
   deprecated: boolean | undefined;
-  errors: Record<string, string | undefined>;
+  /**
+   * Contains error response types like 400, 401, 404, 500, etc.
+   * The mapping contains status codes as keys and response types as values.
+   * If the response type is `null`, it typically indicates an error response with no content.
+   */
+  errors: Record<string, string[] | null | undefined>;
   requestBody: OpenAPISchemaType['paths'][string]['post']['requestBody'];
-  success: Record<string, string | undefined>;
+  /**
+   * Contains successful response types like 200, 201, 204, etc.
+   * The mapping contains status codes as keys and response types as values.
+   * If the response type is `null`, it typically indicates a 204-like response with no content.
+   */
+  success: Record<string, string[] | null | undefined>;
   parameters:
     | {
         name: string;

--- a/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
+++ b/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
@@ -10,10 +10,18 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": "Update the onboarding documents of an entity.",
         "errors": {
-          "400": "application/json",
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "400": [
+            "application/json",
+          ],
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postEntitiesIdDocuments",
@@ -67,7 +75,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "success": {
-          "201": "application/json",
+          "201": [
+            "application/json",
+          ],
         },
         "summary": "Update entity onboarding documents",
       },
@@ -83,9 +93,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": "Retrieve a specific approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getApprovalPoliciesId",
@@ -141,7 +157,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get an approval policy by ID",
       },
@@ -149,9 +167,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": "Delete an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
@@ -203,7 +227,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Delete an approval policy",
       },
@@ -211,9 +237,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": "Update an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "patch",
         "name": "patchApprovalPoliciesId",
@@ -274,7 +306,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Update an approval policy",
       },
@@ -290,9 +324,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "405": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "405": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFiles",
@@ -339,7 +379,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a files by ID",
       },
@@ -347,7 +389,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postFiles",
@@ -373,7 +417,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         },
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Upload a files by ID",
       },
@@ -381,7 +427,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteFiles",
@@ -399,7 +447,11 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "requestBody": undefined,
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+            "application/octet-stream",
+          ],
+          "204": null,
         },
         "summary": "Delete all files",
       },
@@ -407,7 +459,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
         "deprecated": true,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFileList",
@@ -444,7 +498,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a file list",
       },
@@ -465,10 +521,18 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": "Update the onboarding documents of an entity.",
         "errors": {
-          "400": "application/json",
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "400": [
+            "application/json",
+          ],
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postEntitiesIdDocuments",
@@ -522,7 +586,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "success": {
-          "201": "application/json",
+          "201": [
+            "application/json",
+          ],
         },
         "summary": "Update entity onboarding documents",
       },
@@ -538,9 +604,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": "Retrieve a specific approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getApprovalPoliciesId",
@@ -596,7 +668,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get an approval policy by ID",
       },
@@ -604,9 +678,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": "Delete an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
@@ -658,7 +738,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Delete an approval policy",
       },
@@ -666,9 +748,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": "Update an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "patch",
         "name": "patchApprovalPoliciesId",
@@ -729,7 +817,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Update an approval policy",
       },
@@ -745,9 +835,15 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "405": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "405": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFiles",
@@ -794,7 +890,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a files by ID",
       },
@@ -802,7 +900,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postFiles",
@@ -828,7 +928,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         },
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Upload a files by ID",
       },
@@ -836,7 +938,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteFiles",
@@ -854,7 +958,11 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "requestBody": undefined,
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+            "application/octet-stream",
+          ],
+          "204": null,
         },
         "summary": "Delete all files",
       },
@@ -862,7 +970,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
         "deprecated": true,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFileList",
@@ -899,7 +1009,9 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a file list",
       },
@@ -920,10 +1032,18 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": "Update the onboarding documents of an entity.",
         "errors": {
-          "400": "application/json",
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "400": [
+            "application/json",
+          ],
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postEntitiesIdDocuments",
@@ -977,7 +1097,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "success": {
-          "201": "application/json",
+          "201": [
+            "application/json",
+          ],
         },
         "summary": "Update entity onboarding documents",
       },
@@ -993,9 +1115,15 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": "Retrieve a specific approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getApprovalPoliciesId",
@@ -1051,7 +1179,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get an approval policy by ID",
       },
@@ -1059,9 +1189,15 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": "Delete an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
@@ -1113,7 +1249,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Delete an approval policy",
       },
@@ -1121,9 +1259,15 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": "Update an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "patch",
         "name": "patchApprovalPoliciesId",
@@ -1184,7 +1328,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Update an approval policy",
       },
@@ -1200,9 +1346,15 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "405": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "405": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFiles",
@@ -1249,7 +1401,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a files by ID",
       },
@@ -1257,7 +1411,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postFiles",
@@ -1283,7 +1439,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         },
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Upload a files by ID",
       },
@@ -1291,7 +1449,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteFiles",
@@ -1309,7 +1469,11 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "requestBody": undefined,
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+            "application/octet-stream",
+          ],
+          "204": null,
         },
         "summary": "Delete all files",
       },
@@ -1317,7 +1481,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
         "deprecated": true,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFileList",
@@ -1354,7 +1520,9 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a file list",
       },
@@ -1375,9 +1543,15 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "405": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "405": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFiles",
@@ -1424,7 +1598,9 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a files by ID",
       },
@@ -1432,7 +1608,9 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postFiles",
@@ -1458,7 +1636,9 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         },
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Upload a files by ID",
       },
@@ -1466,7 +1646,9 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteFiles",
@@ -1484,7 +1666,11 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "requestBody": undefined,
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+            "application/octet-stream",
+          ],
+          "204": null,
         },
         "summary": "Delete all files",
       },
@@ -1492,7 +1678,9 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
         "deprecated": true,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFileList",
@@ -1529,7 +1717,9 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a file list",
       },
@@ -1550,10 +1740,18 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": "Update the onboarding documents of an entity.",
         "errors": {
-          "400": "application/json",
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "400": [
+            "application/json",
+          ],
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postEntitiesIdDocuments",
@@ -1607,7 +1805,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "success": {
-          "201": "application/json",
+          "201": [
+            "application/json",
+          ],
         },
         "summary": "Update entity onboarding documents",
       },
@@ -1623,9 +1823,15 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": "Retrieve a specific approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getApprovalPoliciesId",
@@ -1681,7 +1887,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get an approval policy by ID",
       },
@@ -1689,9 +1897,15 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": "Delete an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteApprovalPoliciesId",
@@ -1743,7 +1957,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Delete an approval policy",
       },
@@ -1751,9 +1967,15 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": "Update an existing approval policy.",
         "errors": {
-          "401": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "401": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "patch",
         "name": "patchApprovalPoliciesId",
@@ -1814,7 +2036,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Update an approval policy",
       },
@@ -1830,9 +2054,15 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "405": "application/json",
-          "422": "application/json",
-          "default": "application/json",
+          "405": [
+            "application/json",
+          ],
+          "422": [
+            "application/json",
+          ],
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFiles",
@@ -1879,7 +2109,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a files by ID",
       },
@@ -1887,7 +2119,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "post",
         "name": "postFiles",
@@ -1913,7 +2147,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
         },
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Upload a files by ID",
       },
@@ -1921,7 +2157,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": undefined,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "delete",
         "name": "deleteFiles",
@@ -1939,7 +2177,11 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "requestBody": undefined,
         "security": undefined,
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+            "application/octet-stream",
+          ],
+          "204": null,
         },
         "summary": "Delete all files",
       },
@@ -1947,7 +2189,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
         "deprecated": true,
         "description": undefined,
         "errors": {
-          "default": "application/json",
+          "default": [
+            "application/json",
+          ],
         },
         "method": "get",
         "name": "getFileList",
@@ -1984,7 +2228,9 @@ exports[`getServices > matches snapshot with default options 1`] = `
           },
         ],
         "success": {
-          "200": "application/json",
+          "200": [
+            "application/json",
+          ],
         },
         "summary": "Get a file list",
       },

--- a/packages/plugin/src/lib/open-api/getContent.ts
+++ b/packages/plugin/src/lib/open-api/getContent.ts
@@ -1,26 +1,13 @@
-const BASIC_MEDIA_TYPES = [
-  'application/json-patch+json',
-  'application/json',
-  'application/x-www-form-urlencoded',
-  'text/json',
-  'text/plain',
-  'multipart/form-data',
-  'multipart/mixed',
-  'multipart/related',
-  'multipart/batch',
-];
+export const getContentMediaType = (
+  content:
+    | {
+        [contentType: string]: { schema: unknown } | { type: unknown };
+      }
+    | undefined
+) => {
+  const mediaTypes = Object.keys(content || {});
 
-export const getContentMediaType = (content: {
-  [contentType: string]: { schema: unknown };
-}) => {
-  const basicMediaTypeWithSchema = Object.keys(content)
-    .filter((mediaType) => {
-      const cleanMediaType = mediaType.split(';')[0].trim();
-      return BASIC_MEDIA_TYPES.includes(cleanMediaType);
-    })
-    .find((mediaType) => content[mediaType]?.schema);
+  if (!mediaTypes.length) return null;
 
-  if (basicMediaTypeWithSchema) return basicMediaTypeWithSchema;
-
-  return Object.keys(content).find((mediaType) => content[mediaType]?.schema);
+  return mediaTypes;
 };

--- a/packages/plugin/src/lib/open-api/getServices.ts
+++ b/packages/plugin/src/lib/open-api/getServices.ts
@@ -59,12 +59,13 @@ export const getServices = (
 
       const { success, errors } = Object.entries(
         methodOperation.responses
-      ).reduce(
+      ).reduce<
+        Record<
+          'errors' | 'success',
+          Record<string, string[] | null | undefined>
+        >
+      >(
         (acc, [statusCode, response]) => {
-          if (!response.content || typeof response.content !== 'object') {
-            return acc;
-          }
-
           const statusType =
             statusCode !== 'default' && // See "default" response https://swagger.io/docs/specification/describing-responses/#default
             Number(statusCode) < 400
@@ -79,7 +80,7 @@ export const getServices = (
             },
           };
         },
-        {} as Record<'errors' | 'success', Record<string, string | undefined>>
+        { errors: {}, success: {} }
       );
 
       const serviceFallbackBaseName = 'Default';

--- a/packages/react-client/src/tests/msw/handlers.ts
+++ b/packages/react-client/src/tests/msw/handlers.ts
@@ -375,12 +375,14 @@ type ServiceOperationResponseData<
     error?: infer Error;
   };
 }
-  ? Data | Error
+  ? IfUnknownThenUndefined<Data> | IfUnknownThenUndefined<Error>
   : TService extends {
         types: {
           data?: infer Data;
           error?: infer Error;
         };
       }
-    ? Data | Error
+    ? IfUnknownThenUndefined<Data> | IfUnknownThenUndefined<Error>
     : never;
+
+type IfUnknownThenUndefined<T> = T extends unknown ? undefined : T;

--- a/packages/react-client/turbo.json
+++ b/packages/react-client/turbo.json
@@ -4,10 +4,12 @@
   "tasks": {
     "typecheck": {
       "cache": true,
-      "dependsOn": [
-        "^build",
-        "build"
-      ]
+      "dependsOn": ["build"]
+    },
+    "test": {
+      "cache": true,
+      "dependsOn": ["build"],
+      "outputs": ["coverage/**"]
     }
   }
 }

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -1199,7 +1199,7 @@ type DeleteFilesSchema = {
     url: "/files";
 };
 type DeleteFilesParameters = paths["/files"]["delete"]["parameters"];
-type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"];
+type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
 type DeleteFilesError = paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"];
 type DeleteFilesBody = undefined;
 type GetFileListSchema = {

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/queryable-write-operations/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/queryable-write-operations/services/FilesService.ts.snapshot.ts
@@ -1846,7 +1846,7 @@ type DeleteFilesSchema = {
     url: "/files";
 };
 type DeleteFilesParameters = paths["/files"]["delete"]["parameters"];
-type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"];
+type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
 type DeleteFilesError = paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"];
 type DeleteFilesBody = undefined;
 type GetFileListSchema = {

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -335,41 +335,52 @@ const getOperationResponseFactory = (
     return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
 
   return factory.createUnionTypeNode(
-    responses.map(([statusCode, mediaType]) => {
-      if (!mediaType)
-        return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
+    responses
+      .map(([statusCode, mediaType]) => {
+        if (mediaType === null)
+          return factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
 
-      return factory.createIndexedAccessTypeNode(
-        factory.createIndexedAccessTypeNode(
+        if (!mediaType)
+          return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
+
+        return mediaType.map((mediaTypeItem) =>
           factory.createIndexedAccessTypeNode(
             factory.createIndexedAccessTypeNode(
               factory.createIndexedAccessTypeNode(
                 factory.createIndexedAccessTypeNode(
-                  factory.createTypeReferenceNode(
-                    factory.createIdentifier('paths'),
-                    undefined
+                  factory.createIndexedAccessTypeNode(
+                    factory.createIndexedAccessTypeNode(
+                      factory.createTypeReferenceNode(
+                        factory.createIdentifier('paths'),
+                        undefined
+                      ),
+                      factory.createLiteralTypeNode(
+                        factory.createStringLiteral(operation.path)
+                      )
+                    ),
+                    factory.createLiteralTypeNode(
+                      factory.createStringLiteral(operation.method)
+                    )
                   ),
                   factory.createLiteralTypeNode(
-                    factory.createStringLiteral(operation.path)
+                    factory.createStringLiteral('responses')
                   )
                 ),
                 factory.createLiteralTypeNode(
-                  factory.createStringLiteral(operation.method)
+                  factory.createStringLiteral(statusCode)
                 )
               ),
               factory.createLiteralTypeNode(
-                factory.createStringLiteral('responses')
+                factory.createStringLiteral('content')
               )
             ),
             factory.createLiteralTypeNode(
-              factory.createStringLiteral(statusCode)
+              factory.createStringLiteral(mediaTypeItem)
             )
-          ),
-          factory.createLiteralTypeNode(factory.createStringLiteral('content'))
-        ),
-        factory.createLiteralTypeNode(factory.createStringLiteral(mediaType))
-      );
-    })
+          )
+        );
+      })
+      .flat()
   );
 };
 

--- a/packages/test-fixtures/openapi.json
+++ b/packages/test-fixtures/openapi.json
@@ -591,8 +591,16 @@
                     }
                   }
                 }
+              },
+              "application/octet-stream": {
+                "description": "Successfully deleted file dump",
+                "type": "string",
+                "format": "binary"
               }
             }
+          },
+          "204": {
+            "description": "No Content - Operation completed successfully, no data returned"
           },
           "default": {
             "description": "Internal Server Error",


### PR DESCRIPTION
Now, for both successful and error responses, we generate types for all possible response outcomes.
For instance, if a 204 (No Content) response is possible, we now explicitly generate a type for it
(represented as `undefined` in the generated code) instead of omitting it.