### PR TITLE
fix(315): handle empty response with `null`

### DIFF
--- a/.changeset/red-mirrors-add.md
+++ b/.changeset/red-mirrors-add.md
@@ -1,0 +1,7 @@
+---
+'@openapi-qraft/tanstack-query-react-plugin': minor
+'@openapi-qraft/test-fixtures': minor
+'@openapi-qraft/react': minor
+---
+
+Generate `null` type and return `null` data for the empty (204) responses instead of an empty object `{}`.

--- a/.changeset/strong-mugs-fry.md
+++ b/.changeset/strong-mugs-fry.md
@@ -8,4 +8,4 @@ Generate types for empty responses
 
 Now, for both successful and error responses, we generate types for all possible response outcomes.
 For instance, if a 204 (No Content) response is possible, we now explicitly generate a type for it
-(represented as `undefined` in the generated code) instead of omitting it.
+(represented as `null` in the generated code) instead of omitting it.

--- a/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/no-extra-options.ts.snapshot.ts
@@ -71,6 +71,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/files/trash": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Trash files */
+        delete: operations["trash_files"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/files/list": {
         parameters: {
             query?: never;
@@ -554,6 +571,49 @@ export interface operations {
         parameters: {
             query?: {
                 all?: boolean;
+                pendingOnly?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        query?: {
+                            all?: boolean;
+                        };
+                    };
+                };
+            };
+            /** @description No Content - Operation completed successfully, no data returned */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorSchemaResponse"];
+                };
+            };
+        };
+    };
+    trash_files: {
+        parameters: {
+            query?: {
+                pendingOnly?: boolean;
             };
             header?: never;
             path?: never;
@@ -575,7 +635,7 @@ export interface operations {
                     "application/octet-stream": unknown;
                 };
             };
-            /** @description No Content - Operation completed successfully, no data returned */
+            /** @description No files trashed */
             204: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-enum-exports.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-enum-exports.ts.snapshot.ts
@@ -217,6 +217,7 @@ export interface operations {
         parameters: {
             query?: {
                 all?: boolean;
+                pendingOnly?: boolean;
             };
             header?: never;
             path?: never;
@@ -235,7 +236,6 @@ export interface operations {
                             all?: boolean;
                         };
                     };
-                    "application/octet-stream": unknown;
                 };
             };
             /** @description No Content - Operation completed successfully, no data returned */

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-exports.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-explicit-component-exports.ts.snapshot.ts
@@ -217,6 +217,7 @@ export interface operations {
         parameters: {
             query?: {
                 all?: boolean;
+                pendingOnly?: boolean;
             };
             header?: never;
             path?: never;
@@ -235,7 +236,6 @@ export interface operations {
                             all?: boolean;
                         };
                     };
-                    "application/octet-stream": unknown;
                 };
             };
             /** @description No Content - Operation completed successfully, no data returned */

--- a/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
+++ b/packages/openapi-typescript-plugin/src/__snapshots__/with-extra-options.ts.snapshot.ts
@@ -23,6 +23,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/files/trash": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Trash files */
+        delete: operations["trash_files"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/files/list": {
         parameters: {
             query?: never;
@@ -237,6 +254,49 @@ export interface operations {
         parameters: {
             query?: {
                 all?: boolean;
+                pendingOnly?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        query?: {
+                            all?: boolean;
+                        };
+                    };
+                };
+            };
+            /** @description No Content - Operation completed successfully, no data returned */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorSchemaResponse"];
+                };
+            };
+        };
+    };
+    trash_files: {
+        parameters: {
+            query?: {
+                pendingOnly?: boolean;
             };
             header?: never;
             path?: never;
@@ -258,7 +318,7 @@ export interface operations {
                     "application/octet-stream": unknown;
                 };
             };
-            /** @description No Content - Operation completed successfully, no data returned */
+            /** @description No files trashed */
             204: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
+++ b/packages/plugin/src/lib/open-api/__snapshots__/getServices.spec.ts.snap
@@ -442,8 +442,47 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
               "type": "boolean",
             },
           },
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
         ],
         "path": "/files",
+        "requestBody": undefined,
+        "security": undefined,
+        "success": {
+          "200": [
+            "application/json",
+          ],
+          "204": null,
+        },
+        "summary": "Delete all files",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": [
+            "application/json",
+          ],
+        },
+        "method": "delete",
+        "name": "trashFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files/trash",
         "requestBody": undefined,
         "security": undefined,
         "success": {
@@ -453,7 +492,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: endpoint" 1`] = `
           ],
           "204": null,
         },
-        "summary": "Delete all files",
+        "summary": "Trash files",
       },
       {
         "deprecated": true,
@@ -953,8 +992,47 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
               "type": "boolean",
             },
           },
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
         ],
         "path": "/files",
+        "requestBody": undefined,
+        "security": undefined,
+        "success": {
+          "200": [
+            "application/json",
+          ],
+          "204": null,
+        },
+        "summary": "Delete all files",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": [
+            "application/json",
+          ],
+        },
+        "method": "delete",
+        "name": "trashFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files/trash",
         "requestBody": undefined,
         "security": undefined,
         "success": {
@@ -964,7 +1042,7 @@ exports[`getServices > matches snapshot with "serviceNameBase: tags" 1`] = `
           ],
           "204": null,
         },
-        "summary": "Delete all files",
+        "summary": "Trash files",
       },
       {
         "deprecated": true,
@@ -1464,8 +1542,47 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
               "type": "boolean",
             },
           },
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
         ],
         "path": "/files",
+        "requestBody": undefined,
+        "security": undefined,
+        "success": {
+          "200": [
+            "application/json",
+          ],
+          "204": null,
+        },
+        "summary": "Delete all files",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": [
+            "application/json",
+          ],
+        },
+        "method": "delete",
+        "name": "trashFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files/trash",
         "requestBody": undefined,
         "security": undefined,
         "success": {
@@ -1475,7 +1592,7 @@ exports[`getServices > matches snapshot with custom \`postfixServices\` 1`] = `
           ],
           "204": null,
         },
-        "summary": "Delete all files",
+        "summary": "Trash files",
       },
       {
         "deprecated": true,
@@ -1661,8 +1778,47 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
               "type": "boolean",
             },
           },
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
         ],
         "path": "/files",
+        "requestBody": undefined,
+        "security": undefined,
+        "success": {
+          "200": [
+            "application/json",
+          ],
+          "204": null,
+        },
+        "summary": "Delete all files",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": [
+            "application/json",
+          ],
+        },
+        "method": "delete",
+        "name": "trashFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files/trash",
         "requestBody": undefined,
         "security": undefined,
         "success": {
@@ -1672,7 +1828,7 @@ exports[`getServices > matches snapshot with custom \`servicesGlob\` 1`] = `
           ],
           "204": null,
         },
-        "summary": "Delete all files",
+        "summary": "Trash files",
       },
       {
         "deprecated": true,
@@ -2172,8 +2328,47 @@ exports[`getServices > matches snapshot with default options 1`] = `
               "type": "boolean",
             },
           },
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
         ],
         "path": "/files",
+        "requestBody": undefined,
+        "security": undefined,
+        "success": {
+          "200": [
+            "application/json",
+          ],
+          "204": null,
+        },
+        "summary": "Delete all files",
+      },
+      {
+        "deprecated": undefined,
+        "description": undefined,
+        "errors": {
+          "default": [
+            "application/json",
+          ],
+        },
+        "method": "delete",
+        "name": "trashFiles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pendingOnly",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+            },
+          },
+        ],
+        "path": "/files/trash",
         "requestBody": undefined,
         "security": undefined,
         "success": {
@@ -2183,7 +2378,7 @@ exports[`getServices > matches snapshot with default options 1`] = `
           ],
           "204": null,
         },
-        "summary": "Delete all files",
+        "summary": "Trash files",
       },
       {
         "deprecated": true,

--- a/packages/react-client/src/lib/responseUtils.ts
+++ b/packages/react-client/src/lib/responseUtils.ts
@@ -9,7 +9,7 @@ export async function processResponse<TData, TError>(
 ): Promise<RequestFnResponse<TData, TError>> {
   if (response.status === 204 || response.headers.get('Content-Length') === '0')
     return (
-      response.ok ? { data: {}, response } : { error: {}, response }
+      response.ok ? { data: null, response } : { error: null, response }
     ) as RequestFnResponse<TData, TError>;
 
   const contentType = response.headers.get('Content-Type')?.toLowerCase();

--- a/packages/react-client/src/tests/msw/handlers.ts
+++ b/packages/react-client/src/tests/msw/handlers.ts
@@ -143,6 +143,14 @@ export const handlers = [
       const query = getQueryParameters<Services['files']['deleteFiles']>(
         request.url
       );
+
+      if (query?.pendingOnly) {
+        return new HttpResponse(null, {
+          status: 204,
+          statusText: 'No pending files deleted',
+        });
+      }
+
       return HttpResponse.json({ query });
     }
   ),

--- a/packages/react-client/src/tests/qraftAPIClient.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.test.tsx
@@ -1202,6 +1202,34 @@ describe('Qraft uses Mutations', () => {
     });
   });
 
+  it('handles useMutations for 204 responses and returns `null` data', async () => {
+    const { qraft, queryClient } = createClient();
+
+    const { result } = renderHook(() => qraft.files.deleteFiles.useMutation(), {
+      wrapper: (props) => <Providers {...props} queryClient={queryClient} />,
+    });
+
+    act(() => {
+      result.current.mutate({ query: { pendingOnly: true } });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(null);
+    });
+
+    result.current.data satisfies
+      | {
+          query?: {
+            all?: boolean;
+          };
+        }
+      | null
+      | undefined;
+
+    // @ts-expect-error - never satisfies never
+    result.current.data satisfies never;
+  });
+
   it('supports useMutation with predefined parameters', async () => {
     const { qraft, queryClient } = createClient();
 

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -627,6 +627,129 @@ export interface FilesService {
             body: DeleteFilesBody;
         };
     };
+    /** @summary Trash files */
+    trashFiles: {
+        /** @summary Trash files */
+        getMutationKey(parameters: DeepReadonly<TrashFilesParameters> | void): ServiceOperationMutationKey<TrashFilesSchema, TrashFilesParameters>;
+        /**
+         * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
+         * Handles loading state, optimistic updates, and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
+         * @example Mutation with predefined parameters, e.g., for updating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * mutate(body);
+         * ```
+         * @example Mutation without predefined parameters, e.g., for creating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation()
+         * mutate({
+         *     body: bodyPayload,
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * });
+         * ```
+         */
+        useMutation<TVariables extends TrashFilesBody, TContext = unknown>(parameters: DeepReadonly<TrashFilesParameters>, options?: ServiceOperationUseMutationOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TVariables, TrashFilesError | Error, TContext>): UseMutationResult<TrashFilesData, TrashFilesError | Error, TVariables | void, TContext>;
+        /**
+         * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
+         * Handles loading state, optimistic updates, and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
+         * @example Mutation with predefined parameters, e.g., for updating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * mutate(body);
+         * ```
+         * @example Mutation without predefined parameters, e.g., for creating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation()
+         * mutate({
+         *     body: bodyPayload,
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * });
+         * ```
+         */
+        useMutation<TVariables extends MutationVariables<TrashFilesBody, TrashFilesParameters>, TContext = unknown>(parameters: void, options?: ServiceOperationUseMutationOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TVariables, TrashFilesError | Error, TContext>): UseMutationResult<TrashFilesData, TrashFilesError | Error, TVariables, TContext>;
+        /**
+         * Returns the count of currently in-progress mutations.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useIsMutating|`useIsMutating(...)` documentation}
+         * @example Check how many mutations are currently in progress for the specified service method.
+         * ```ts
+         * const trashFilesTotal = qraft.filesService.trashFiles.useIsMutating()
+         * ```
+         * @example Check how many mutations are currently in progress with the specified parameters.
+         * ```ts
+         * const trashFilesTotal = qraft.filesService.trashFiles.useIsMutating({
+         *     parameters: {
+         *         query: {
+         *             pendingOnly: pendingOnly
+         *         }
+         *     }
+         * })
+         * ```
+         */
+        useIsMutating<TContext = unknown>(filters?: MutationFiltersByParameters<TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext> | MutationFiltersByMutationKey<TrashFilesSchema, TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext>): number;
+        /** @summary Trash files */
+        isMutating<TContext>(filters?: MutationFiltersByParameters<TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext> | MutationFiltersByMutationKey<TrashFilesSchema, TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext>): number;
+        /** @summary Trash files */
+        (options: ServiceOperationMutationFnOptions<TrashFilesBody, TrashFilesParameters>, client?: (schema: TrashFilesSchema, options: ServiceOperationMutationFnOptions<TrashFilesBody, TrashFilesParameters>) => Promise<RequestFnResponse<TrashFilesData, TrashFilesError>>): Promise<RequestFnResponse<TrashFilesData, TrashFilesError>>;
+        /**
+         * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutationState|`useMutationState(...)` documentation}
+         * @example Get all variables of all running mutations.
+         * ```ts
+         * const trashFilesPendingMutationVariables = qraft.filesService.trashFiles.useMutationState({
+         *     filters: {
+         *         status: "pending"
+         *     },
+         *     select: mutation => mutation.state.variables
+         * })
+         * ```
+         * @example Get all data for specific mutations via the `parameters`.
+         * ```ts
+         * const trashFilesMutationData = qraft.filesService.trashFiles.useMutationState({
+         *     filters: {
+         *         parameters: {
+         *             query: {
+         *                 pendingOnly: pendingOnly
+         *             }
+         *         }
+         *     },
+         *     select: mutation => mutation.state.data
+         * })
+         * ```
+         */
+        useMutationState<TContext = unknown, TResult = MutationState<TrashFilesData, TrashFilesError | Error, MutationVariables<TrashFilesBody, TrashFilesParameters>, TContext>>(options?: {
+            filters?: MutationFiltersByParameters<TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext> | MutationFiltersByMutationKey<TrashFilesSchema, TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext>;
+            select?: (mutation: Mutation<TrashFilesData, TrashFilesError | Error, MutationVariables<TrashFilesBody, TrashFilesParameters>, TContext>) => TResult;
+        }): Array<TResult>;
+        schema: TrashFilesSchema;
+        types: {
+            parameters: TrashFilesParameters;
+            data: TrashFilesData;
+            error: TrashFilesError;
+            body: TrashFilesBody;
+        };
+    };
     /**
      * @deprecated
      * @summary Get a file list
@@ -1133,6 +1256,10 @@ export const filesService: {
     deleteFiles: {
         schema: DeleteFilesSchema;
     };
+    /** @summary Trash files */
+    trashFiles: {
+        schema: TrashFilesSchema;
+    };
     /**
      * @deprecated
      * @summary Get a file list
@@ -1159,6 +1286,12 @@ export const filesService: {
         schema: {
             method: "delete",
             url: "/files"
+        }
+    },
+    trashFiles: {
+        schema: {
+            method: "delete",
+            url: "/files/trash"
         }
     },
     getFileList: {
@@ -1199,9 +1332,17 @@ type DeleteFilesSchema = {
     url: "/files";
 };
 type DeleteFilesParameters = paths["/files"]["delete"]["parameters"];
-type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
+type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | undefined;
 type DeleteFilesError = paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"];
 type DeleteFilesBody = undefined;
+type TrashFilesSchema = {
+    method: "delete";
+    url: "/files/trash";
+};
+type TrashFilesParameters = paths["/files/trash"]["delete"]["parameters"];
+type TrashFilesData = paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
+type TrashFilesError = paths["/files/trash"]["delete"]["responses"]["default"]["content"]["application/json"];
+type TrashFilesBody = undefined;
 type GetFileListSchema = {
     method: "get";
     url: "/files/list";

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/explicit-import-extensions/services/FilesService.ts.snapshot.ts
@@ -1332,7 +1332,7 @@ type DeleteFilesSchema = {
     url: "/files";
 };
 type DeleteFilesParameters = paths["/files"]["delete"]["parameters"];
-type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | undefined;
+type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | null;
 type DeleteFilesError = paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"];
 type DeleteFilesBody = undefined;
 type TrashFilesSchema = {
@@ -1340,7 +1340,7 @@ type TrashFilesSchema = {
     url: "/files/trash";
 };
 type TrashFilesParameters = paths["/files/trash"]["delete"]["parameters"];
-type TrashFilesData = paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
+type TrashFilesData = paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | null;
 type TrashFilesError = paths["/files/trash"]["delete"]["responses"]["default"]["content"]["application/json"];
 type TrashFilesBody = undefined;
 type GetFileListSchema = {

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/queryable-write-operations/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/queryable-write-operations/services/FilesService.ts.snapshot.ts
@@ -2316,7 +2316,7 @@ type DeleteFilesSchema = {
     url: "/files";
 };
 type DeleteFilesParameters = paths["/files"]["delete"]["parameters"];
-type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | undefined;
+type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | null;
 type DeleteFilesError = paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"];
 type DeleteFilesBody = undefined;
 type TrashFilesSchema = {
@@ -2324,7 +2324,7 @@ type TrashFilesSchema = {
     url: "/files/trash";
 };
 type TrashFilesParameters = paths["/files/trash"]["delete"]["parameters"];
-type TrashFilesData = paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
+type TrashFilesData = paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | null;
 type TrashFilesError = paths["/files/trash"]["delete"]["responses"]["default"]["content"]["application/json"];
 type TrashFilesBody = undefined;
 type GetFileListSchema = {

--- a/packages/tanstack-query-react-plugin/src/__snapshots__/queryable-write-operations/services/FilesService.ts.snapshot.ts
+++ b/packages/tanstack-query-react-plugin/src/__snapshots__/queryable-write-operations/services/FilesService.ts.snapshot.ts
@@ -1267,6 +1267,466 @@ export interface FilesService {
             body: DeleteFilesBody;
         };
     };
+    /** @summary Trash files */
+    trashFiles: {
+        /** @summary Trash files */
+        cancelQueries<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>, options?: CancelOptions): Promise<void>;
+        /** @summary Trash files */
+        getQueryKey(parameters: DeepReadonly<TrashFilesParameters> | void): ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>;
+        /**
+         * Performs asynchronous data fetching, manages loading states and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useQuery|`useQuery(...)` documentation}
+         * @example Query without parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery()
+         * ```
+         * @example Query with parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * ```
+         */
+        useQuery<TData = TrashFilesData>(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options?: Omit<UndefinedInitialDataOptions<TrashFilesData, TrashFilesError, TData, ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>>, "queryKey">): UseQueryResult<TData, TrashFilesError | Error>;
+        /**
+         * Performs asynchronous data fetching, manages loading states and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useQuery|`useQuery(...)` documentation}
+         * @example Query without parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery()
+         * ```
+         * @example Query with parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * ```
+         */
+        useQuery<TData = TrashFilesData>(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options: Omit<DefinedInitialDataOptions<TrashFilesData, TrashFilesError, TData, ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>>, "queryKey">): DefinedUseQueryResult<TData, TrashFilesError | Error>;
+        /** @summary Trash files */
+        fetchInfiniteQuery<TPageParam extends TrashFilesParameters>(options: ServiceOperationFetchInfiniteQueryOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, DeepReadonly<TPageParam>, TrashFilesError> | void): Promise<OperationInfiniteData<TrashFilesData, TrashFilesParameters>>;
+        /** @summary Trash files */
+        prefetchInfiniteQuery<TPageParam extends TrashFilesParameters>(options: ServiceOperationFetchInfiniteQueryOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, DeepReadonly<TPageParam>, TrashFilesError> | void): Promise<void>;
+        /** @summary Trash files */
+        ensureInfiniteQueryData<TPageParam extends TrashFilesParameters>(options: ServiceOperationEnsureInfiniteQueryDataOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, DeepReadonly<TPageParam>, TrashFilesError> | void): Promise<OperationInfiniteData<TrashFilesData, TrashFilesParameters>>;
+        /** @summary Trash files */
+        fetchQuery(options: ServiceOperationFetchQueryOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TrashFilesError> | void): Promise<TrashFilesData>;
+        /** @summary Trash files */
+        prefetchQuery(options: ServiceOperationFetchQueryOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TrashFilesError> | void): Promise<void>;
+        /** @summary Trash files */
+        ensureQueryData(options: ServiceOperationEnsureQueryDataOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TrashFilesError> | void): Promise<TrashFilesData>;
+        /** @summary Trash files */
+        getInfiniteQueryData(parameters: ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void)): OperationInfiniteData<TrashFilesData, TrashFilesParameters> | undefined;
+        /** @summary Trash files */
+        getQueriesData<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>): TInfinite extends true ? Array<[
+            queryKey: ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters>,
+            data: NoInfer<OperationInfiniteData<TrashFilesData, TrashFilesParameters>> | undefined
+        ]> : Array<[
+            queryKey: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>,
+            data: TrashFilesData | undefined
+        ]>;
+        /** @summary Trash files */
+        getQueryData(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void)): TrashFilesData | undefined;
+        /** @summary Trash files */
+        getQueryState(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void)): QueryState<TrashFilesData, TrashFilesError> | undefined;
+        /** @summary Trash files */
+        getInfiniteQueryState(parameters: DeepReadonly<TrashFilesParameters> | ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters> | void): QueryState<OperationInfiniteData<TrashFilesData, TrashFilesParameters>, TrashFilesError> | undefined;
+        /** @summary Trash files */
+        invalidateQueries<TInfinite extends boolean = false>(filters?: InvalidateQueryFilters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>, options?: InvalidateOptions): Promise<void>;
+        /** @summary Trash files */
+        isFetching<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>): number;
+        /** @summary Trash files */
+        refetchQueries<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>, options?: RefetchOptions): Promise<void>;
+        /** @summary Trash files */
+        removeQueries<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>): void;
+        /** @summary Trash files */
+        resetQueries<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>, options?: ResetOptions): Promise<void>;
+        /** @summary Trash files */
+        setInfiniteQueryData(parameters: (DeepReadonly<TrashFilesParameters> | undefined) | ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters>, updater: Updater<NoInfer<OperationInfiniteData<TrashFilesData, TrashFilesParameters>> | undefined, NoInfer<DeepReadonly<OperationInfiniteData<TrashFilesData, TrashFilesParameters>>> | undefined>, options?: SetDataOptions): OperationInfiniteData<TrashFilesData, TrashFilesParameters> | undefined;
+        /** @summary Trash files */
+        setQueriesData<TInfinite extends boolean = false>(filters: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>, updater: Updater<NoInfer<TrashFilesData> | undefined, NoInfer<TrashFilesData> | undefined>, options?: SetDataOptions): Array<TrashFilesData | undefined>;
+        /** @summary Trash files */
+        setQueryData(parameters: (DeepReadonly<TrashFilesParameters> | undefined) | ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>, updater: Updater<NoInfer<TrashFilesData> | undefined, NoInfer<DeepReadonly<TrashFilesData>> | undefined>, options?: SetDataOptions): TrashFilesData | undefined;
+        /** @summary Trash files */
+        getInfiniteQueryKey(parameters: DeepReadonly<TrashFilesParameters> | void): ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters>;
+        /**
+         * Performs asynchronous data fetching with support for infinite scrolling scenarios.
+         * Manages paginated data and provides utilities for fetching additional pages.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useInfiniteQuery|`useInfiniteQuery(...)` documentation}
+         *
+         * @example Infinite Query
+         * ```ts
+         * const { data, isLoading, fetchNextPage } = qraft.filesService.trashFiles.useInfiniteQuery({}, {
+         *     initialPageParam: {
+         *         query: {
+         *             pendingOnly: initialPendingOnly
+         *         }
+         *     },
+         *     getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => getNextPageParams(lastPage)
+         * })
+         *
+         * console.log(data);
+         * fetchNextPage(); // Fetch the next page
+         * ```
+         */
+        useInfiniteQuery<TPageParam extends TrashFilesParameters, TQueryFnData = TrashFilesData, TData = OperationInfiniteData<TQueryFnData, TrashFilesParameters>>(parameters: ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options: Omit<UndefinedInitialDataInfiniteOptions<TQueryFnData, TrashFilesError, TData, ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters>, PartialParameters<DeepReadonly<TPageParam>>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TQueryFnData, PartialParameters<DeepReadonly<TPageParam>>>): UseInfiniteQueryResult<TData, TrashFilesError | Error>;
+        /**
+         * Performs asynchronous data fetching with support for infinite scrolling scenarios.
+         * Manages paginated data and provides utilities for fetching additional pages.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useInfiniteQuery|`useInfiniteQuery(...)` documentation}
+         *
+         * @example Infinite Query
+         * ```ts
+         * const { data, isLoading, fetchNextPage } = qraft.filesService.trashFiles.useInfiniteQuery({}, {
+         *     initialPageParam: {
+         *         query: {
+         *             pendingOnly: initialPendingOnly
+         *         }
+         *     },
+         *     getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => getNextPageParams(lastPage)
+         * })
+         *
+         * console.log(data);
+         * fetchNextPage(); // Fetch the next page
+         * ```
+         */
+        useInfiniteQuery<TPageParam extends TrashFilesParameters, TQueryFnData = TrashFilesData, TData = OperationInfiniteData<TQueryFnData, TrashFilesParameters>>(parameters: ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options: Omit<DefinedInitialDataInfiniteOptions<TQueryFnData, TrashFilesError, TData, ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters>, PartialParameters<DeepReadonly<TPageParam>>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TrashFilesData, PartialParameters<DeepReadonly<TPageParam>>>): DefinedUseInfiniteQueryResult<TData, TrashFilesError | Error>;
+        /**
+         * Monitors the number of queries currently fetching, matching the provided filters.
+         * Useful for creating loading indicators or performing actions based on active requests.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useIsFetching|`useIsFetching(...)` documentation}
+         * @example Checks the total number of queries fetching from the specified service method,
+         * both normal and infinite. If no parameters are provided, no filtering is applied.
+         * ```ts
+         * const trashFilesTotal = qraft.filesService.trashFiles.useIsFetching()
+         * ```
+         * @example Checks the number of normal queries fetching with the specified parameters.
+         * ```ts
+         * const trashFilesByParametersTotal = qraft.filesService.trashFiles.useIsFetching({
+         *     infinite: false,
+         *     parameters: {
+         *         query: {
+         *             pendingOnly: pendingOnly
+         *         }
+         *     }
+         * })
+         * ```
+         */
+        useIsFetching<TInfinite extends boolean = false>(filters?: QueryFiltersByParameters<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError> | QueryFiltersByQueryKey<TrashFilesSchema, TrashFilesData, TInfinite, TrashFilesParameters, TrashFilesError>): number;
+        /**
+         * Allows you to execute multiple asynchronous data fetching operations concurrently. This is especially useful for managing complex data dependencies in parallel.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useQueries|`useQueries(...)` documentation}
+         * @example Multiple queries. Returns `data`, `error`, `isSuccess` and other properties.
+         * ```ts
+         * const trashFilesResults = qraft.filesService.trashFiles.useQueries({
+         *     queries: [
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly1
+         *             }
+         *         },
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly2
+         *             }
+         *         }
+         *     ]
+         * });
+         * trashFilesResults.forEach(({ isSuccess, data, error }) => console.log({ isSuccess, data, error }));
+         * ```
+         * @example Combined results. Only the data will be returned.
+         * ```ts
+         * const trashFilesCombinedResults = qraft.filesService.trashFiles.useQueries({
+         *     combine: results => results.map(result => result.data),
+         *     queries: [
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly1
+         *             }
+         *         },
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly2
+         *             }
+         *         }
+         *     ]
+         * });
+         * trashFilesCombinedResults.forEach(data => console.log({ data }));
+         * ```
+         */
+        useQueries<T extends Array<UseQueryOptionsForUseQueries<TrashFilesSchema, TrashFilesParameters, TrashFilesData, TrashFilesError>>, TCombinedResult = Array<UseQueryResult<TrashFilesData, TrashFilesError>>>(options: {
+            queries: T;
+            combine?: (results: Array<UseQueryResult<TrashFilesData, TrashFilesError>>) => TCombinedResult;
+        }): TCombinedResult;
+        /** @summary Trash files */
+        getQueryKey(parameters: DeepReadonly<TrashFilesParameters> | void): ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>;
+        /**
+         * Performs asynchronous data fetching, manages loading states and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useQuery|`useQuery(...)` documentation}
+         * @example Query without parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery()
+         * ```
+         * @example Query with parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * ```
+         */
+        useQuery<TData = TrashFilesData>(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options?: Omit<UndefinedInitialDataOptions<TrashFilesData, TrashFilesError, TData, ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>>, "queryKey">): UseQueryResult<TData, TrashFilesError | Error>;
+        /**
+         * Performs asynchronous data fetching, manages loading states and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useQuery|`useQuery(...)` documentation}
+         * @example Query without parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery()
+         * ```
+         * @example Query with parameters
+         * ```ts
+         * const { data, isLoading } = qraft.filesService.trashFiles.useQuery({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * ```
+         */
+        useQuery<TData = TrashFilesData>(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options: Omit<DefinedInitialDataOptions<TrashFilesData, TrashFilesError, TData, ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>>, "queryKey">): DefinedUseQueryResult<TData, TrashFilesError | Error>;
+        /**
+         * Performs asynchronous data fetching with support for infinite scrolling scenarios.
+         * Manages paginated data and provides utilities for fetching additional pages.
+         * It functions similarly to `useInfiniteQuery`, but with added support for React Suspense.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseInfiniteQuery|`useSuspenseInfiniteQuery(...)` documentation}
+         *
+         * @example Suspense Infinite Query
+         * ```ts
+         * const { data, isLoading, fetchNextPage } = qraft.filesService.trashFiles.useSuspenseInfiniteQuery({}, {
+         *     initialPageParam: {
+         *         query: {
+         *             pendingOnly: initialPendingOnly
+         *         }
+         *     },
+         *     getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => getNextPageParams(lastPage)
+         * })
+         *
+         * console.log(data);
+         * fetchNextPage(); // Fetch the next page
+         * ```
+         */
+        useSuspenseInfiniteQuery<TPageParam extends TrashFilesParameters, TData = TrashFilesData>(parameters: ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options: Omit<UseSuspenseInfiniteQueryOptions<TrashFilesData, TrashFilesError, OperationInfiniteData<TData, TrashFilesParameters>, TrashFilesData, ServiceOperationInfiniteQueryKey<TrashFilesSchema, TrashFilesParameters>, PartialParameters<DeepReadonly<TPageParam>>>, "queryKey" | "getPreviousPageParam" | "getNextPageParam" | "initialPageParam"> & InfiniteQueryPageParamsOptions<TrashFilesData, PartialParameters<DeepReadonly<TPageParam>>>): UseSuspenseInfiniteQueryResult<OperationInfiniteData<TData, TrashFilesParameters>, TrashFilesError | Error>;
+        /**
+         * Allows you to execute multiple asynchronous data fetching operations concurrently with Suspense support.
+         * Similar to useQueries but integrates with React Suspense for loading states.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQueries|`useSuspenseQueries(...)` documentation}
+         * @example Basic usage with Suspense
+         * ```ts
+         * const trashFilesData = qraft.filesService.trashFiles.useSuspenseQueries({
+         *     queries: [
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly1
+         *             }
+         *         },
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly2
+         *             }
+         *         }
+         *     ]
+         * });
+         * trashFilesResults.forEach(({ isSuccess, data, error }) => console.log({ isSuccess, data, error }));
+         * ```
+         * @example With data transformation using combine
+         * ```ts
+         * const trashFilesCombinedData = qraft.filesService.trashFiles.useSuspenseQueries({
+         *     combine: results => results.map(result => result.data),
+         *     queries: [
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly1
+         *             }
+         *         },
+         *         {
+         *             query: {
+         *                 pendingOnly: pendingOnly2
+         *             }
+         *         }
+         *     ]
+         * });
+         * trashFilesCombinedData.forEach(data => console.log({ data }));
+         * ```
+         */
+        useSuspenseQueries<T extends Array<UseQueryOptionsForUseSuspenseQuery<TrashFilesSchema, TrashFilesParameters, TrashFilesData, TrashFilesError>>, TCombinedResult = Array<UseSuspenseQueryResult<TrashFilesData, TrashFilesError>>>(options: {
+            queries: T;
+            combine?: (results: Array<WithOptional<UseSuspenseQueryResult<TrashFilesData, TrashFilesError>, "data">>) => TCombinedResult;
+        }): TCombinedResult;
+        /**
+         * Performs asynchronous data fetching with Suspense support.
+         * Similar to useQuery but integrates with React Suspense for loading states.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useSuspenseQuery|`useSuspenseQuery(...)` documentation}
+         * @example Suspense Query without parameters
+         * ```ts
+         * const data = qraft.filesService.trashFiles.useSuspenseQuery()
+         * ```
+         * @example Suspense Query with parameters
+         * ```ts
+         * const data = qraft.filesService.trashFiles.useSuspenseQuery({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * ```
+         */
+        useSuspenseQuery<TData = TrashFilesData>(parameters: ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters> | (DeepReadonly<TrashFilesParameters> | void), options?: Omit<UseSuspenseQueryOptions<TrashFilesData, TrashFilesError, TData, ServiceOperationQueryKey<TrashFilesSchema, TrashFilesParameters>>, "queryKey">): UseSuspenseQueryResult<TData, TrashFilesError | Error>;
+        /** @summary Trash files */
+        getMutationKey(parameters: DeepReadonly<TrashFilesParameters> | void): ServiceOperationMutationKey<TrashFilesSchema, TrashFilesParameters>;
+        /**
+         * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
+         * Handles loading state, optimistic updates, and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
+         * @example Mutation with predefined parameters, e.g., for updating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * mutate(body);
+         * ```
+         * @example Mutation without predefined parameters, e.g., for creating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation()
+         * mutate({
+         *     body: bodyPayload,
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * });
+         * ```
+         */
+        useMutation<TVariables extends TrashFilesBody, TContext = unknown>(parameters: DeepReadonly<TrashFilesParameters>, options?: ServiceOperationUseMutationOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TVariables, TrashFilesError | Error, TContext>): UseMutationResult<TrashFilesData, TrashFilesError | Error, TVariables | void, TContext>;
+        /**
+         * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
+         * Handles loading state, optimistic updates, and error handling.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
+         * @example Mutation with predefined parameters, e.g., for updating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation({
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * })
+         * mutate(body);
+         * ```
+         * @example Mutation without predefined parameters, e.g., for creating
+         * ```ts
+         * const { mutate, isPending } = qraft.filesService.trashFiles.useMutation()
+         * mutate({
+         *     body: bodyPayload,
+         *     query: {
+         *         pendingOnly: pendingOnly
+         *     }
+         * });
+         * ```
+         */
+        useMutation<TVariables extends MutationVariables<TrashFilesBody, TrashFilesParameters>, TContext = unknown>(parameters: void, options?: ServiceOperationUseMutationOptions<TrashFilesSchema, TrashFilesData, TrashFilesParameters, TVariables, TrashFilesError | Error, TContext>): UseMutationResult<TrashFilesData, TrashFilesError | Error, TVariables, TContext>;
+        /**
+         * Returns the count of currently in-progress mutations.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useIsMutating|`useIsMutating(...)` documentation}
+         * @example Check how many mutations are currently in progress for the specified service method.
+         * ```ts
+         * const trashFilesTotal = qraft.filesService.trashFiles.useIsMutating()
+         * ```
+         * @example Check how many mutations are currently in progress with the specified parameters.
+         * ```ts
+         * const trashFilesTotal = qraft.filesService.trashFiles.useIsMutating({
+         *     parameters: {
+         *         query: {
+         *             pendingOnly: pendingOnly
+         *         }
+         *     }
+         * })
+         * ```
+         */
+        useIsMutating<TContext = unknown>(filters?: MutationFiltersByParameters<TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext> | MutationFiltersByMutationKey<TrashFilesSchema, TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext>): number;
+        /** @summary Trash files */
+        isMutating<TContext>(filters?: MutationFiltersByParameters<TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext> | MutationFiltersByMutationKey<TrashFilesSchema, TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext>): number;
+        /** @summary Trash files */
+        (options: ServiceOperationMutationFnOptions<TrashFilesBody, TrashFilesParameters>, client?: (schema: TrashFilesSchema, options: ServiceOperationMutationFnOptions<TrashFilesBody, TrashFilesParameters>) => Promise<RequestFnResponse<TrashFilesData, TrashFilesError>>): Promise<RequestFnResponse<TrashFilesData, TrashFilesError>>;
+        /**
+         * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
+         *
+         * @summary Trash files
+         * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutationState|`useMutationState(...)` documentation}
+         * @example Get all variables of all running mutations.
+         * ```ts
+         * const trashFilesPendingMutationVariables = qraft.filesService.trashFiles.useMutationState({
+         *     filters: {
+         *         status: "pending"
+         *     },
+         *     select: mutation => mutation.state.variables
+         * })
+         * ```
+         * @example Get all data for specific mutations via the `parameters`.
+         * ```ts
+         * const trashFilesMutationData = qraft.filesService.trashFiles.useMutationState({
+         *     filters: {
+         *         parameters: {
+         *             query: {
+         *                 pendingOnly: pendingOnly
+         *             }
+         *         }
+         *     },
+         *     select: mutation => mutation.state.data
+         * })
+         * ```
+         */
+        useMutationState<TContext = unknown, TResult = MutationState<TrashFilesData, TrashFilesError | Error, MutationVariables<TrashFilesBody, TrashFilesParameters>, TContext>>(options?: {
+            filters?: MutationFiltersByParameters<TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext> | MutationFiltersByMutationKey<TrashFilesSchema, TrashFilesBody, TrashFilesData, TrashFilesParameters, TrashFilesError | Error, TContext>;
+            select?: (mutation: Mutation<TrashFilesData, TrashFilesError | Error, MutationVariables<TrashFilesBody, TrashFilesParameters>, TContext>) => TResult;
+        }): Array<TResult>;
+        schema: TrashFilesSchema;
+        types: {
+            parameters: TrashFilesParameters;
+            data: TrashFilesData;
+            error: TrashFilesError;
+            body: TrashFilesBody;
+        };
+    };
     /**
      * @deprecated
      * @summary Get a file list
@@ -1773,6 +2233,10 @@ export const filesService: {
     deleteFiles: {
         schema: DeleteFilesSchema;
     };
+    /** @summary Trash files */
+    trashFiles: {
+        schema: TrashFilesSchema;
+    };
     /**
      * @deprecated
      * @summary Get a file list
@@ -1799,6 +2263,12 @@ export const filesService: {
         schema: {
             method: "delete",
             url: "/files"
+        }
+    },
+    trashFiles: {
+        schema: {
+            method: "delete",
+            url: "/files/trash"
         }
     },
     getFileList: {
@@ -1846,9 +2316,17 @@ type DeleteFilesSchema = {
     url: "/files";
 };
 type DeleteFilesParameters = paths["/files"]["delete"]["parameters"];
-type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
+type DeleteFilesData = paths["/files"]["delete"]["responses"]["200"]["content"]["application/json"] | undefined;
 type DeleteFilesError = paths["/files"]["delete"]["responses"]["default"]["content"]["application/json"];
 type DeleteFilesBody = undefined;
+type TrashFilesSchema = {
+    method: "delete";
+    url: "/files/trash";
+};
+type TrashFilesParameters = paths["/files/trash"]["delete"]["parameters"];
+type TrashFilesData = paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/json"] | paths["/files/trash"]["delete"]["responses"]["200"]["content"]["application/octet-stream"] | undefined;
+type TrashFilesError = paths["/files/trash"]["delete"]["responses"]["default"]["content"]["application/json"];
+type TrashFilesBody = undefined;
 type GetFileListSchema = {
     method: "get";
     url: "/files/list";

--- a/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
+++ b/packages/tanstack-query-react-plugin/src/ts-factory/getServiceFactory.ts
@@ -338,7 +338,7 @@ const getOperationResponseFactory = (
     responses
       .map(([statusCode, mediaType]) => {
         if (mediaType === null)
-          return factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
+          return factory.createLiteralTypeNode(factory.createNull());
 
         if (!mediaType)
           return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);

--- a/packages/test-fixtures/openapi.json
+++ b/packages/test-fixtures/openapi.json
@@ -571,6 +571,64 @@
             },
             "name": "all",
             "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "pendingOnly",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "object",
+                      "properties": {
+                        "all": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content - Operation completed successfully, no data returned"
+          },
+          "default": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files/trash": {
+      "delete": {
+        "tags": ["Files"],
+        "summary": "Trash files",
+        "operationId": "trash_files",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "pendingOnly",
+            "in": "query"
           }
         ],
         "responses": {
@@ -600,7 +658,7 @@
             }
           },
           "204": {
-            "description": "No Content - Operation completed successfully, no data returned"
+            "description": "No files trashed"
           },
           "default": {
             "description": "Internal Server Error",


### PR DESCRIPTION
Generate `null` type and return `null` data for the empty (204) responses instead of an empty object `{}`.