### PR TITLE
fix: support for `--enum-values` and `--dedupe-enums` options

### DIFF
--- a/.changeset/old-carpets-repair.md
+++ b/.changeset/old-carpets-repair.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/openapi-typescript-plugin': patch
+---
+
+Fixed support for `--enum-values` and `--dedupe-enums` options to improve enum handling and reduce duplication.

--- a/packages/openapi-typescript-plugin/src/generateSchemaTypes.ts
+++ b/packages/openapi-typescript-plugin/src/generateSchemaTypes.ts
@@ -42,6 +42,8 @@ export async function generateSchemaTypes(
     defaultNonNullable: args.defaultNonNullable,
     emptyObjectsUnknown: args.emptyObjectsUnknown,
     enum: args.enum,
+    enumValues: args.enumValues,
+    dedupeEnums: args.dedupeEnums,
     excludeDeprecated: args.excludeDeprecated,
     exportType: args.exportType,
     immutable: args.immutable,

--- a/packages/react-client/redocly.yaml
+++ b/packages/react-client/redocly.yaml
@@ -11,6 +11,7 @@ apis:
         openapi-typescript: true
       output-dir: src/tests/fixtures/api
       clean: true
+      enum-values: true
       explicit-import-extensions: true
       openapi-types-file-name: openapi.ts
       filter-services:


### PR DESCRIPTION
This PR adds support for the `--enum-values` and `--dedupe-enums` options to enhance enum processing. It enables better control over generated enum values and removes duplicates when applicable.