### PR TITLE
fix(tanstack-query-react-types): add missing readonly modifiers in RequestFnInfo type

### DIFF
--- a/.changeset/calm-facts-swim.md
+++ b/.changeset/calm-facts-swim.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/tanstack-query-react-types': patch
+---
+
+Clarify `RequestFnInfo` type by adding missing `readonly` modifiers for consistency and correctness.

--- a/packages/tanstack-query-react-types/src/shared/RequestFn.ts
+++ b/packages/tanstack-query-react-types/src/shared/RequestFn.ts
@@ -60,7 +60,7 @@ export interface RequestFnInfo
    * Base URL to use for the request
    * @example 'https://api.example.com'
    */
-  baseUrl?: string;
+  readonly baseUrl?: string;
 
   /**
    * OpenAPI parameters
@@ -84,10 +84,10 @@ export interface RequestFnInfo
   /**
    * TanStack Query Meta
    */
-  meta?: Record<string, unknown>;
+  readonly meta?: Record<string, unknown>;
 
   /** An AbortSignal to set request's signal. */
-  signal?: AbortSignal | null;
+  readonly signal?: AbortSignal | null;
 }
 
 /**


### PR DESCRIPTION
Clarify `RequestFnInfo` type by adding missing `readonly` modifiers for consistency and correctness.