### PR TITLE
fix(react-client): improve `body` parameter handling in queryable write operations

### DIFF
--- a/.changeset/ten-monkeys-lie.md
+++ b/.changeset/ten-monkeys-lie.md
@@ -1,0 +1,5 @@
+---
+'@openapi-qraft/react': patch
+---
+
+Refactored parameter preparation logic for queryable write operations to correctly handle body parameters in both regular and infinite queries. The update extracts shared logic into a reusable utility and ensures consistent parameter handling across all affected query methods.

--- a/packages/react-client/src/lib/prepareRequestFnParameters.ts
+++ b/packages/react-client/src/lib/prepareRequestFnParameters.ts
@@ -1,0 +1,70 @@
+import { shelfMerge } from './shelfMerge.js';
+
+/**
+ * Prepares parameters and body for requestFn calls, handling infinite query logic
+ * @param queryParams - The query parameters that may contain body
+ * @param pageParam - The page parameter for infinite queries
+ * @param infinite - Whether this is for an infinite query
+ * @returns Object with prepared parameters and body
+ */
+export function prepareRequestFnParameters<TQueryParams>(
+  queryParams: TQueryParams,
+  pageParam: unknown,
+  infinite: boolean
+): {
+  parameters: TQueryParams extends { body: any }
+    ? Omit<TQueryParams, 'body'>
+    : TQueryParams;
+  body: BodyInit | undefined;
+} {
+  const { body, ...parameters } = queryParams as {
+    body?: BodyInit;
+  } & TQueryParams;
+
+  if (!infinite) {
+    return {
+      parameters: parameters as never,
+      body: body as never,
+    };
+  }
+
+  // Handle infinite query parameters
+  const processedParameters = shelfMerge(
+    2,
+    parameters,
+    omitBodyFromPageParam(pageParam)
+  ) as never;
+
+  const processedBody = mergeBodyWithPageParam(body, pageParam) as never;
+
+  return {
+    parameters: processedParameters,
+    body: processedBody,
+  };
+}
+
+/**
+ * Remove body from pageParam if it exists
+ */
+function omitBodyFromPageParam(pageParam: unknown) {
+  if (pageParam && typeof pageParam === 'object' && 'body' in pageParam) {
+    const { body: _body, ...pageParameters } = pageParam;
+    return pageParameters;
+  }
+
+  return pageParam;
+}
+
+/**
+ * Merge body with pageParam.body if pageParam contains body
+ */
+function mergeBodyWithPageParam(
+  body: BodyInit | undefined,
+  pageParam: unknown
+): BodyInit | undefined {
+  if (pageParam && typeof pageParam === 'object' && 'body' in pageParam) {
+    return shelfMerge(1, body, pageParam.body) as BodyInit;
+  }
+
+  return body;
+}

--- a/packages/react-client/src/lib/useComposeUseQueryOptions.ts
+++ b/packages/react-client/src/lib/useComposeUseQueryOptions.ts
@@ -6,9 +6,9 @@ import type { CreateAPIQueryClientOptions } from '../qraftAPIClient.js';
 import type { OperationSchema } from './requestFn.js';
 import { composeInfiniteQueryKey } from './composeInfiniteQueryKey.js';
 import { composeQueryKey } from './composeQueryKey.js';
+import { prepareRequestFnParameters } from './prepareRequestFnParameters.js';
 import { requestFnResponseRejecter } from './requestFnResponseRejecter.js';
 import { requestFnResponseResolver } from './requestFnResponseResolver.js';
-import { shelfMerge } from './shelfMerge.js';
 
 /**
  * Composes the options for useQuery, useInfiniteQuery, useSuspenseQuery, and useSuspenseQueries.
@@ -25,46 +25,17 @@ export function useComposeUseQueryOptions(
   const queryFn =
     options?.queryFn ??
     function ({ queryKey: [, queryParams], signal, meta, pageParam }) {
-      const { body, ...parameters } = queryParams as {
-        body: BodyInit;
-        parameters: Record<string, unknown>;
-      };
+      const { parameters, body } = prepareRequestFnParameters(
+        queryParams,
+        pageParam,
+        infinite
+      );
 
       return qraftOptions
         .requestFn(schema, {
-          // @ts-expect-error - Too complex to type
-          parameters: infinite
-            ? (shelfMerge(
-                2,
-                parameters,
-                (function omitBodyFromParameters() {
-                  if (
-                    pageParam &&
-                    typeof pageParam === 'object' &&
-                    'body' in pageParam
-                  ) {
-                    const { body: _body, ...pageParameters } = pageParam;
-                    return pageParameters;
-                  }
-
-                  return pageParam;
-                })()
-              ) as never)
-            : parameters,
+          parameters: parameters as never,
           baseUrl: qraftOptions.baseUrl,
-          body: infinite
-            ? (function shelfMergeBody() {
-                if (
-                  pageParam &&
-                  typeof pageParam === 'object' &&
-                  'body' in pageParam
-                ) {
-                  return shelfMerge(1, body, pageParam.body) as BodyInit;
-                }
-
-                return body;
-              })()
-            : body,
+          body,
           signal,
           meta,
         })

--- a/packages/react-client/src/lib/useComposeUseQueryOptions.ts
+++ b/packages/react-client/src/lib/useComposeUseQueryOptions.ts
@@ -34,10 +34,37 @@ export function useComposeUseQueryOptions(
         .requestFn(schema, {
           // @ts-expect-error - Too complex to type
           parameters: infinite
-            ? (shelfMerge(2, parameters, pageParam) as never)
+            ? (shelfMerge(
+                2,
+                parameters,
+                (function omitBodyFromParameters() {
+                  if (
+                    pageParam &&
+                    typeof pageParam === 'object' &&
+                    'body' in pageParam
+                  ) {
+                    const { body: _body, ...pageParameters } = pageParam;
+                    return pageParameters;
+                  }
+
+                  return pageParam;
+                })()
+              ) as never)
             : parameters,
           baseUrl: qraftOptions.baseUrl,
-          body,
+          body: infinite
+            ? (function shelfMergeBody() {
+                if (
+                  pageParam &&
+                  typeof pageParam === 'object' &&
+                  'body' in pageParam
+                ) {
+                  return shelfMerge(1, body, pageParam.body) as BodyInit;
+                }
+
+                return body;
+              })()
+            : body,
           signal,
           meta,
         })

--- a/packages/react-client/src/tests/msw/handlers.ts
+++ b/packages/react-client/src/tests/msw/handlers.ts
@@ -69,6 +69,7 @@ export const handlers = [
         name: body.name!,
         description: body.description!,
         id: path.approval_policy_id,
+        trigger: body.trigger,
       });
     }
   ),

--- a/packages/react-client/src/tests/qraftAPIClient.queryable-write-operations.test.tsx
+++ b/packages/react-client/src/tests/qraftAPIClient.queryable-write-operations.test.tsx
@@ -9,7 +9,7 @@ import { createAPIClient } from './fixtures/queryable-write-operations-api/index
 const baseUrl = 'https://api.sandbox.monite.com/v1';
 
 describe('Queryable write operations', () => {
-  it('queries writable operations with a specific body', async () => {
+  it('queries writable operations with a specific body for useQuery', async () => {
     const queryClient = new QueryClient();
     const qraft = createAPIClient({
       requestFn,
@@ -44,6 +44,85 @@ describe('Queryable write operations', () => {
         id: '2',
         name: 'New Name',
         description: 'New Description',
+      });
+    });
+  });
+
+  it('queries writable operations with a specific body for fetchQuery', async () => {
+    const queryClient = new QueryClient();
+    const qraft = createAPIClient({
+      requestFn,
+      baseUrl,
+      queryClient,
+    });
+
+    const result =
+      await qraft.approvalPolicies.patchApprovalPoliciesId.fetchQuery({
+        parameters: {
+          header: {
+            'x-monite-version': '1',
+            'x-monite-entity-id': '2',
+          },
+          path: {
+            approval_policy_id: '2',
+          },
+          body: {
+            name: 'New Name',
+            description: 'New Description',
+          },
+        },
+      });
+
+    await waitFor(() => {
+      expect(result).toEqual({
+        id: '2',
+        name: 'New Name',
+        description: 'New Description',
+      });
+    });
+  });
+
+  it('queries writable operations with a specific body for fetchInfiniteQuery', async () => {
+    const queryClient = new QueryClient();
+    const qraft = createAPIClient({
+      requestFn,
+      baseUrl,
+      queryClient,
+    });
+
+    const result =
+      await qraft.approvalPolicies.patchApprovalPoliciesId.fetchInfiniteQuery({
+        parameters: {
+          header: {
+            'x-monite-version': '1',
+            'x-monite-entity-id': '2',
+          },
+          path: {
+            approval_policy_id: '2',
+          },
+          body: {
+            name: 'New Name',
+            description: 'New Description',
+          },
+        },
+        initialPageParam: {
+          body: {
+            trigger: true,
+          },
+        },
+      });
+
+    await waitFor(() => {
+      expect(result).toEqual({
+        pageParams: [{ body: { trigger: true } }],
+        pages: [
+          {
+            id: '2',
+            name: 'New Name',
+            description: 'New Description',
+            trigger: true,
+          },
+        ],
       });
     });
   });


### PR DESCRIPTION
Refactored parameter preparation logic for queryable write operations to correctly handle body parameters in both regular and infinite queries. The update extracts shared logic into a reusable utility and ensures consistent parameter handling across all affected query methods.

### Affected Methods
- `fetchQuery` - Fixed body parameter extraction
- `fetchInfiniteQuery` - Fixed body parameter merging with pageParam
- `prefetchQuery` - Fixed body parameter extraction  
- `prefetchInfiniteQuery` - Fixed body parameter merging with pageParam
- `ensureQueryData` - Fixed body parameter extraction
- `ensureInfiniteQueryData` - Fixed body parameter merging with pageParam
- `useInfiniteQuery` - Fixed body parameter merging with pageParam
- `useSuspenseQuery` - Fixed body parameter extraction
- `useSuspenseInfiniteQuery` - Fixed body parameter merging with pageParam