### PR TITLE
chore: add package metadata

### DIFF
--- a/.changeset/add-license-metadata.md
+++ b/.changeset/add-license-metadata.md
@@ -1,0 +1,15 @@
+---
+'@openapi-qraft/cli': patch
+'@openapi-qraft/plugin': patch
+'@openapi-qraft/openapi-typescript-plugin': patch
+'@openapi-qraft/react': patch
+'@openapi-qraft/tanstack-query-react-plugin': patch
+'@openapi-qraft/tanstack-query-react-types': patch
+'@qraft/asyncapi-plugin': patch
+'@qraft/asyncapi-typescript-plugin': patch
+'@qraft/cli': patch
+'@qraft/cli-utils': patch
+'@qraft/plugin': patch
+---
+
+Add MIT license metadata to package manifests.

--- a/packages/asyncapi-plugin/package.json
+++ b/packages/asyncapi-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@qraft/asyncapi-plugin",
   "version": "1.0.0-beta.8",
+  "license": "MIT",
   "packageManager": "yarn@4.0.2",
   "type": "module",
   "scripts": {

--- a/packages/asyncapi-typescript-plugin/package.json
+++ b/packages/asyncapi-typescript-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@qraft/asyncapi-typescript-plugin",
   "version": "1.0.0-beta.8",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@qraft/cli-utils",
   "version": "1.0.0-beta.8",
+  "license": "MIT",
   "description": "Shared CLI utilities for Qraft code generation tools",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@qraft/cli",
   "version": "1.0.0-beta.8",
+  "license": "MIT",
   "description": "CLI tool for generating type-safe code from OpenAPI and AsyncAPI specifications",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -13,6 +13,9 @@
     "url": "git+https://github.com/OpenAPI-Qraft/openapi-qraft.git",
     "directory": "packages/eslint-plugin-query"
   },
+  "bugs": {
+    "url": "https://github.com/OpenAPI-Qraft/openapi-qraft/issues"
+  },
   "scripts": {
     "build": "yarn clean && NODE_ENV=production rollup --config rollup.config.mjs && tsc --project tsconfig.build.json --emitDeclarationOnly",
     "typecheck": "tsc --noEmit",

--- a/packages/openapi-cli/package.json
+++ b/packages/openapi-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openapi-qraft/cli",
   "version": "2.15.0-beta.9",
+  "license": "MIT",
   "description": "CLI for generating typed TanStack Query React Hooks and services from OpenAPI Document, improving type safety in React apps",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/openapi-plugin/package.json
+++ b/packages/openapi-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openapi-qraft/plugin",
   "version": "2.15.0-beta.9",
+  "license": "MIT",
   "packageManager": "yarn@4.0.2",
   "type": "module",
   "scripts": {

--- a/packages/openapi-typescript-plugin/package.json
+++ b/packages/openapi-typescript-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openapi-qraft/openapi-typescript-plugin",
   "version": "2.15.0-beta.9",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@qraft/plugin",
   "version": "1.0.0-beta.8",
+  "license": "MIT",
   "packageManager": "yarn@4.0.2",
   "type": "module",
   "scripts": {

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openapi-qraft/react",
   "version": "2.15.0-beta.9",
+  "license": "MIT",
   "description": "OpenAPI client for React, providing type-safe requests and dynamic TanStack Query React Hooks via a modular, Proxy-based architecture.",
   "scripts": {
     "build": "NODE_ENV=production rollup --config rollup.config.mjs && tsc --project tsconfig.build.json --emitDeclarationOnly",

--- a/packages/tanstack-query-react-plugin/package.json
+++ b/packages/tanstack-query-react-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openapi-qraft/tanstack-query-react-plugin",
   "version": "2.15.0-beta.9",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/packages/tanstack-query-react-types/package.json
+++ b/packages/tanstack-query-react-types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openapi-qraft/tanstack-query-react-types",
   "version": "2.15.0-beta.9",
+  "license": "MIT",
   "scripts": {
     "build": "yarn clean && NODE_ENV=production rollup --config rollup.config.mjs && tsc --project tsconfig.build.json --emitDeclarationOnly",
     "dev": "yarn clean && tsc --project tsconfig.build.json --watch --outDir ./dist/esm --noEmitOnError false",


### PR DESCRIPTION
## Summary

- add missing `license: "MIT"` metadata to published OpenAPI Qraft package manifests already covered by this PR
- add `bugs.url` metadata to `@openapi-qraft/eslint-plugin-query`

The new `bugs.url` points to the repository issue tracker:

```json
"bugs": {
  "url": "https://github.com/OpenAPI-Qraft/openapi-qraft/issues"
}
```

This PR only changes package metadata. Runtime code, dependencies, exports, package versions, and build output are unchanged.

## Validation

```sh
node manifest assertion for changed package metadata
git diff --check
(cd packages/eslint-plugin-query && npm pack --dry-run --ignore-scripts --json)
```

The dry-run package includes `package.json`.
