### PR TITLE
chore: add bugs metadata to eslint-plugin-query

### DIFF
--- a/packages/eslint-plugin-query/package.json
+++ b/packages/eslint-plugin-query/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/OpenAPI-Qraft/openapi-qraft/issues"
   }
 }


### PR DESCRIPTION
This PR adds the missing \ugs.url\ metadata to \packages/eslint-plugin-query/package.json\, as identified in charles-microbounties#952.

This ensures the canonical issue tracker is correctly exposed on npm.